### PR TITLE
Korrigert omregning param-casing til å matche PEN

### DIFF
--- a/app/routes/omregning._index.tsx
+++ b/app/routes/omregning._index.tsx
@@ -23,7 +23,7 @@ export default function BatchOpprett_index() {
   const [brukKjoreplan, setBrukKjoreplan] = useState(false)
   const [opprettAlleOppgaver, setOpprettAlleOppgaver] = useState(false)
   const [sjekkYtelseFraAvtaleland, setSjekkYtelseFraAvtaleland] = useState(false)
-  const [brukppen015, setBrukppen015] = useState(false)
+  const [brukPpen015, setBrukPpen015] = useState(false)
 
   const [hasError, setHasError] = useState(false)
   const submit = useSubmit()
@@ -179,9 +179,9 @@ export default function BatchOpprett_index() {
                 </Checkbox>
 
                 <Checkbox
-                  name='brukppen015'
-                  value={brukppen015}
-                  onChange={(event) => setBrukppen015(event.target.checked)}
+                  name='brukPPEN015'
+                  value={brukPpen015}
+                  onChange={(event) => setBrukPpen015(event.target.checked)}
                 >
                   Bruk PPEN015
                 </Checkbox>

--- a/app/routes/omregning.omregning.tsx
+++ b/app/routes/omregning.omregning.tsx
@@ -16,7 +16,7 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
     brukKjoreplan: updates.brukKjoreplan === 'true',
     opprettAlleOppgaver: updates.opprettAlleOppgaver === 'true',
     sjekkYtelseFraAvtaleland: updates.sjekkYtelseFraAvtaleland === 'true',
-    brukppen015: updates.brukppen015 === 'true',
+    brukPpen015: updates.brukPpen015 === 'true',
     kravGjelder: updates.kravGjelder,
     kravArsak: updates.kravArsak,
     toleransegrenseSett: updates.toleransegrenseSett,

--- a/app/types.ts
+++ b/app/types.ts
@@ -165,6 +165,6 @@ export type OmregningRequest = {
   kravArsak: string
   toleransegrenseSett: string
   oppgaveSett: string
-  brukppen015: boolean
+  brukPpen015: boolean
   oppgavePrefiks: string
 }


### PR DESCRIPTION
Rimelig sikker at da jeg startet Omregningsbehandling med id 3125573 i Q2 fra Verdande så hadde jeg huket av for PPEN015, men det skjedde ikke. Antar det er pga denne mismatchen.