### PR TITLE
Legger til visning av foreign key indexer

### DIFF
--- a/app/components/venstre-meny/VenstreMeny.tsx
+++ b/app/components/venstre-meny/VenstreMeny.tsx
@@ -18,6 +18,7 @@ export type Props = {
 
 let administrasjonMeny = [
   ['INFOBANNER_PSAK', `/infobanner`, 'Infobanner i PSAK'],
+  ['MANGLENDE_FOREIGN_KEY_INDEXER', `/manglende-foreign-key-indexer`, 'Manglende indekser for fjernnøkler'],
   ['LAAS_OPP_SAK', `/laas-opp-sak`, 'Lås opp sak'],
   ['LAASTE_VEDTAK', `/laaste-vedtak`, 'Låste vedtak'],
   ['LINKE_DNR_TIL_FNR', `/linke-dnr-fnr`, 'Linke Dnr Fnr'],

--- a/app/routes/manglende-foreign-key-indexer.tsx
+++ b/app/routes/manglende-foreign-key-indexer.tsx
@@ -1,0 +1,189 @@
+import { LoaderFunctionArgs, SetURLSearchParams, useLoaderData, useSearchParams } from 'react-router'
+
+import { BodyShort, Box, CopyButton, Heading, SortState, Table, VStack } from '@navikt/ds-react'
+import React, { useState } from 'react'
+import { ManglendeForeignKeyIndex } from '~/types/vedlikehold'
+import { requireAccessToken } from '~/services/auth.server'
+import { finnManglendeForeignKeyIndexer } from '~/services/vedlikehold.server'
+
+interface ScopedSortState extends SortState {
+  orderBy: keyof ManglendeForeignKeyIndex;
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const accessToken = await requireAccessToken(request)
+
+  const manglendeForeignKeyIndexer = await finnManglendeForeignKeyIndexer(accessToken)
+
+  const url = new URL(request.url)
+  const fkParam = url.searchParams.get('fk')
+
+  const valgtManglendeForeignKeyIndex = fkParam
+    ? manglendeForeignKeyIndexer.find(fk => fk.foreignKeyName === fkParam) ?? null
+    : null
+
+  return {
+    manglendeForeignKeyIndexer,
+    valgtManglendeForeignKeyIndex,
+  }
+}
+
+function ManglendeForeignKeyIndexerTable({ manglendeForeignKeyIndexer, selectedRow, searchParams, setSearchParams }: {
+  manglendeForeignKeyIndexer: ManglendeForeignKeyIndex[]
+  selectedRow: ManglendeForeignKeyIndex | null,
+  searchParams: URLSearchParams
+  setSearchParams: SetURLSearchParams
+}) {
+  const [sort, setSort] = useState<ScopedSortState | undefined>({ 'orderBy': 'tableName', 'direction': 'ascending' })
+
+  const handleSort = (sortKey: ScopedSortState['orderBy']) => {
+    setSort(
+      sort && sortKey === sort.orderBy && sort.direction === 'descending'
+        ? undefined
+        : {
+          orderBy: sortKey,
+          direction:
+            sort && sortKey === sort.orderBy && sort.direction === 'ascending'
+              ? 'descending'
+              : 'ascending',
+        },
+    )
+  }
+
+  function comparator<T>(a: T, b: T, orderBy: keyof T): number {
+    const aVal = a[orderBy]
+    const bVal = b[orderBy]
+    if (aVal == null && bVal != null) return -1
+    if (aVal != null && bVal == null) return 1
+    if (aVal == null && bVal == null) return 0
+    return String(aVal).localeCompare(String(bVal))
+  }
+
+  const sortedData = [...manglendeForeignKeyIndexer].sort((a, b) => {
+    if (!sort) return 0
+
+    return sort.direction === 'ascending'
+      ? comparator(a, b, sort.orderBy)
+      : comparator(b, a, sort.orderBy)
+  })
+
+  return (
+    <Table sort={sort}
+           onSortChange={(sortKey) =>
+             handleSort(sortKey as ScopedSortState['orderBy'])
+           }>
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader sortKey="tableName" sortable>Tabell</Table.ColumnHeader>
+          <Table.ColumnHeader sortKey="foreignKeyName" sortable>Fjernnøkkel</Table.ColumnHeader>
+          <Table.ColumnHeader sortKey="foreignKeyColumns" sortable>Kolonner</Table.ColumnHeader>
+          <Table.ColumnHeader sortKey="referencedTableName" sortable>Referert tabell</Table.ColumnHeader>
+          <Table.ColumnHeader sortKey="referencedColumns" sortable>Refererte kolonner</Table.ColumnHeader>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {sortedData.map((it) => {
+          return (
+            <Table.Row
+              key={`${it.tableName}-${it.foreignKeyName}`}
+              onClick={() => {
+                if (it === selectedRow) {
+                  searchParams.delete("fk")
+                  setSearchParams(searchParams)
+                } else {
+                  setSearchParams({ fk: it.foreignKeyName })
+                }
+              }}
+              selected={it.foreignKeyName === selectedRow?.foreignKeyName}
+            >
+              <Table.DataCell>{it.tableName}</Table.DataCell>
+              <Table.DataCell>{it.foreignKeyName}</Table.DataCell>
+              <Table.DataCell>{it.foreignKeyColumns}</Table.DataCell>
+              <Table.DataCell>{it.referencedTableName}</Table.DataCell>
+              <Table.DataCell>{it.referencedColumns}</Table.DataCell>
+            </Table.Row>)
+        })}
+      </Table.Body>
+    </Table>
+  )
+}
+
+function IndexBox({ index }: { index: ManglendeForeignKeyIndex }) {
+  const indexDdl = `CREATE INDEX ${index.tableName}_${index.foreignKeyColumns.replace(/,/g, '_')}_IDX ON ${index.tableName} (${index.foreignKeyColumns}) ONLINE;`
+
+  return (
+    <Box background={"surface-default"} borderRadius="medium" shadow="medium" padding="2">
+      <VStack gap="5">
+        <Heading size="medium">
+          Opprett indeks for {index.tableName} – {index.foreignKeyName}
+        </Heading>
+        <BodyShort>
+          For å opprette en indeks for en fjernnøkkel som mangler én, kan du bruke følgende SQL-kommando i et
+          Flyway-skript. Husk å endre indeksnavnet dersom du ønsker et annet navn.
+        </BodyShort>
+        <div>
+          <pre>{indexDdl}</pre>
+          <CopyButton copyText={indexDdl} text="Kopier SQL" />
+        </div>
+      </VStack>
+    </Box>
+  )
+}
+
+export default function ManglendeForeignKeyIndexer() {
+  const { manglendeForeignKeyIndexer, valgtManglendeForeignKeyIndex } = useLoaderData<typeof loader>()
+
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  return (
+    <VStack gap="5">
+
+      <Box
+        background={'surface-default'}
+        borderRadius="medium"
+        shadow="medium"
+        padding="2"
+      >
+        <VStack gap="5">
+          <Heading size="large">
+            Manglende indekser for fjernnøkler
+          </Heading>
+
+          {manglendeForeignKeyIndexer.length > 0 ? (
+            <>
+              <BodyShort>
+                Tabellen under viser alle tabeller og kolonner som inngår i en fjernnøkkel (foreign key), men som
+                mangler en tilhørende indeks.
+                Dette kan føre til dårlig ytelse ved sletting av rader i de refererte tabellene.
+                For å sikre god ytelse bør det opprettes indekser på disse kolonnene.
+              </BodyShort>
+              <ManglendeForeignKeyIndexerTable
+                manglendeForeignKeyIndexer={manglendeForeignKeyIndexer}
+                selectedRow={valgtManglendeForeignKeyIndex}
+                searchParams={searchParams}
+                setSearchParams={setSearchParams}
+              ></ManglendeForeignKeyIndexerTable>
+            </>
+          ) : (
+            <BodyShort>
+              Ingen manglende indekser ble funnet 🎉. Alle fjernnøkler har tilhørende indekser.
+            </BodyShort>
+          )}
+        </VStack>
+      </Box>
+      {valgtManglendeForeignKeyIndex ? <IndexBox index={valgtManglendeForeignKeyIndex}/> : manglendeForeignKeyIndexer.length > 0 ? (
+        <Box
+          background={'surface-default'}
+          borderRadius="medium"
+          shadow="medium"
+          padding="2"
+        >
+          <BodyShort>
+            Trykk på en rad i tabellen for å se forslag til hvordan du kan opprette manglende indeks for den valgte
+            raden.
+          </BodyShort>
+        </Box>
+      ) : null}
+    </VStack>
+  )
+}

--- a/app/services/vedlikehold.server.tsx
+++ b/app/services/vedlikehold.server.tsx
@@ -1,0 +1,27 @@
+import { env } from '~/services/env.server'
+import { data } from 'react-router'
+import { ManglendeForeignKeyIndex, ManglendeForeignKeyIndexResponse } from '~/types/vedlikehold'
+
+export async function finnManglendeForeignKeyIndexer(
+  accessToken: string,
+): Promise<ManglendeForeignKeyIndex[]> {
+  const response = await fetch(
+    `${env.penUrl}/api/vedlikehold/manglende-fk-index`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Request-ID': crypto.randomUUID(),
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw data(
+      { message: 'Feil ved henting av manglende foreign key indexer', detail: text },
+      { status: response.status }
+    )
+  }
+
+  return ((await response.json()) as ManglendeForeignKeyIndexResponse).manglendeForeignKeyIndexer
+}

--- a/app/types/vedlikehold.ts
+++ b/app/types/vedlikehold.ts
@@ -1,0 +1,11 @@
+export type ManglendeForeignKeyIndex = {
+  tableName: string
+  foreignKeyName: string
+  foreignKeyColumns: string
+  referencedTableName: string
+  referencedColumns: string
+}
+
+export type ManglendeForeignKeyIndexResponse = {
+  manglendeForeignKeyIndexer: ManglendeForeignKeyIndex[]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1303,9 +1303,9 @@
       }
     },
     "node_modules/@mjackson/headers": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.10.0.tgz",
-      "integrity": "sha512-U1Eu1gF979k7ZoIBsJyD+T5l9MjtPONsZfoXfktsQHPJD0s7SokBGx+tLKDLsOY+gzVYAWS0yRFDNY8cgbQzWQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.11.1.tgz",
+      "integrity": "sha512-uXXhd4rtDdDwkqAuGef1nuafkCa1NlTmEc1Jzc0NL4YiA1yON1NFXuqJ3hOuKvNKQwkiDwdD+JJlKVyz4dunFA==",
       "license": "MIT"
     },
     "node_modules/@mjackson/multipart-parser": {
@@ -1316,12 +1316,6 @@
       "dependencies": {
         "@mjackson/headers": "^0.11.1"
       }
-    },
-    "node_modules/@mjackson/multipart-parser/node_modules/@mjackson/headers": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.11.1.tgz",
-      "integrity": "sha512-uXXhd4rtDdDwkqAuGef1nuafkCa1NlTmEc1Jzc0NL4YiA1yON1NFXuqJ3hOuKvNKQwkiDwdD+JJlKVyz4dunFA==",
-      "license": "MIT"
     },
     "node_modules/@mjackson/node-fetch-server": {
       "version": "0.2.0",
@@ -3088,9 +3082,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.187",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz",
-      "integrity": "sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==",
+      "version": "1.5.189",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
+      "integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5070,6 +5064,12 @@
       "peerDependencies": {
         "remix-auth": "^4.0.0"
       }
+    },
+    "node_modules/remix-auth-oauth2/node_modules/@mjackson/headers": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@mjackson/headers/-/headers-0.10.0.tgz",
+      "integrity": "sha512-U1Eu1gF979k7ZoIBsJyD+T5l9MjtPONsZfoXfktsQHPJD0s7SokBGx+tLKDLsOY+gzVYAWS0yRFDNY8cgbQzWQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",


### PR DESCRIPTION
Sammen med https://github.com/navikt/pensjon-pen/pull/16747 gir dette støtte for å vise manglendende foreign key indexer i Pen

<img width="2120" height="1286" alt="Skjermbilde 2025-07-23 kl  22 13 01" src="https://github.com/user-attachments/assets/3302c94e-4537-4764-85e5-082fc95f2f9f" />
<img width="2120" height="1286" alt="Skjermbilde 2025-07-23 kl  22 13 17" src="https://github.com/user-attachments/assets/007e6df6-bf2a-4b06-b6b2-305bceb68962" />
