### PR TITLE
refactor: migrer Modal til Dialog (øvrige routes)

### DIFF
--- a/app/kontroll-saerskilt-sats/kontroll-saerskilt-sats._index.tsx
+++ b/app/kontroll-saerskilt-sats/kontroll-saerskilt-sats._index.tsx
@@ -1,7 +1,7 @@
-import { Button, Heading, HStack, InlineMessage, Modal, Select, TextField, VStack } from '@navikt/ds-react'
+import { Button, Dialog, Heading, HStack, InlineMessage, Select, TextField, VStack } from '@navikt/ds-react'
 import { endOfMonth, format, parse, startOfDay, startOfMonth } from 'date-fns'
 import { nb } from 'date-fns/locale'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Form, redirect, useNavigation } from 'react-router'
 import BehandlingerTable from '~/components/behandlinger-table/BehandlingerTable'
 import DateTimePicker from '~/components/datetimepicker/DateTimePicker'
@@ -57,7 +57,7 @@ const genererManedsalternativer = () => {
 
 export default function OpprettKontrollSaerskiltSatsRoute({ loaderData }: Route.ComponentProps) {
   const { behandlinger } = loaderData
-  const modalRef = useRef<HTMLDialogElement>(null)
+  const [modalOpen, setModalOpen] = useState(false)
   const navigation = useNavigation()
   const isSubmitting = navigation.state === 'submitting'
 
@@ -156,7 +156,7 @@ export default function OpprettKontrollSaerskiltSatsRoute({ loaderData }: Route.
           </InlineMessage>
 
           <HStack gap="space-16">
-            <Button type="button" onClick={() => modalRef.current?.showModal()} disabled={!kanOpprette}>
+            <Button type="button" onClick={() => setModalOpen(true)} disabled={!kanOpprette}>
               Opprett kontroll
             </Button>
           </HStack>
@@ -174,37 +174,44 @@ export default function OpprettKontrollSaerskiltSatsRoute({ loaderData }: Route.
           behandlingerResponse={behandlinger}
         />
       </div>
-      <Modal ref={modalRef} header={{ heading: 'Start kontroll: særskilt sats' }} size="small">
-        <Modal.Body>
-          <VStack gap="space-16">
-            <div>
-              <b>Kjøremåned:</b> {kjoereMaanedYearMonth ? formatYearMonth(selectedKjoereMaaned) : '-'}
-            </div>
-            <div>
-              <b>Kontrollår:</b> {kontrollAar || '-'}
-            </div>
-            <div>
-              <b>Kjøretidspunkt:</b>{' '}
-              {selectedKjoeretidspunkt ? format(selectedKjoeretidspunkt, "dd.MM.yyyy 'kl.' HH:mm:ss") : 'nå'}
-            </div>
-            <div>
-              <b>Ønsket virkningmåned:</b>{' '}
-              {selectedOensketVirkMaaned ? formatYearMonth(selectedOensketVirkMaaned) : 'ikke satt'}
-            </div>
-            <InlineMessage status="warning" size="small">
-              Etter start kan du ikke angre denne handlingen.
-            </InlineMessage>
-          </VStack>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button form="skjema" type="submit" disabled={!kanOpprette || isSubmitting} loading={isSubmitting}>
-            Start behandling
-          </Button>
-          <Button type="button" variant="secondary" onClick={() => modalRef.current?.close()}>
-            Tilbake
-          </Button>
-        </Modal.Footer>
-      </Modal>
+      <Dialog open={modalOpen} onOpenChange={(open) => setModalOpen(open)} size="small">
+        <Dialog.Popup>
+          <Dialog.Header>
+            <Dialog.Title>Start kontroll: særskilt sats</Dialog.Title>
+          </Dialog.Header>
+          <Dialog.Body>
+            <VStack gap="space-16">
+              <div>
+                <b>Kjøremåned:</b> {kjoereMaanedYearMonth ? formatYearMonth(selectedKjoereMaaned) : '-'}
+              </div>
+              <div>
+                <b>Kontrollår:</b> {kontrollAar || '-'}
+              </div>
+              <div>
+                <b>Kjøretidspunkt:</b>{' '}
+                {selectedKjoeretidspunkt ? format(selectedKjoeretidspunkt, "dd.MM.yyyy 'kl.' HH:mm:ss") : 'nå'}
+              </div>
+              <div>
+                <b>Ønsket virkningmåned:</b>{' '}
+                {selectedOensketVirkMaaned ? formatYearMonth(selectedOensketVirkMaaned) : 'ikke satt'}
+              </div>
+              <InlineMessage status="warning" size="small">
+                Etter start kan du ikke angre denne handlingen.
+              </InlineMessage>
+            </VStack>
+          </Dialog.Body>
+          <Dialog.Footer>
+            <Button form="skjema" type="submit" disabled={!kanOpprette || isSubmitting} loading={isSubmitting}>
+              Start behandling
+            </Button>
+            <Dialog.CloseTrigger>
+              <Button type="button" variant="secondary">
+                Tilbake
+              </Button>
+            </Dialog.CloseTrigger>
+          </Dialog.Footer>
+        </Dialog.Popup>
+      </Dialog>
     </div>
   )
 }

--- a/app/regulering/batch.regulering.ekskludertesaker.tsx
+++ b/app/regulering/batch.regulering.ekskludertesaker.tsx
@@ -2,17 +2,17 @@ import 'chart.js/auto'
 import {
   BodyShort,
   Button,
+  Dialog,
   Heading,
   HStack,
   InlineMessage,
   Loader,
-  Modal,
   Table,
   Tabs,
   Textarea,
   VStack,
 } from '@navikt/ds-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useFetcher } from 'react-router'
 import type { Ekskluderinger, EkskluderingMedKommentar } from '~/regulering/regulering.types'
 
@@ -75,12 +75,12 @@ export default function EkskluderteSaker() {
           </HStack>
           <EkskluderingLeggTilInputBox
             text="Legg til følgende saker i ekskluderingsliste"
-            showModal={openEkskluderingInputBox === 'leggTilEkskluderteBox'}
+            open={openEkskluderingInputBox === 'leggTilEkskluderteBox'}
             onCancel={() => setOpenEkskluderingInputBox(null)}
           />
           <EkskluderingFjernInputBox
             text="Fjern følgende saker fra ekskluderingsliste"
-            showModal={openEkskluderingInputBox === 'fjernEkskluderteBox'}
+            open={openEkskluderingInputBox === 'fjernEkskluderteBox'}
             onCancel={() => setOpenEkskluderingInputBox(null)}
           />
         </VStack>
@@ -89,19 +89,12 @@ export default function EkskluderteSaker() {
   )
 }
 
-export function EkskluderingLeggTilInputBox(props: { text: string; showModal: boolean; onCancel: () => void }) {
-  const ref = useRef<HTMLDialogElement>(null)
+export function EkskluderingLeggTilInputBox(props: { text: string; open: boolean; onCancel: () => void }) {
   const fetcher = useFetcher()
   const [saksnummerToAddListe, setSaksnummerToAddListe] = useState('')
   const [kommentarToAdd, setKommentarToAdd] = useState('')
   const response = fetcher.data as OppdaterEksluderteSakerResponse | undefined
   const [harLagtTilSaker, setHarLagtTilSaker] = useState(false)
-
-  if (props.showModal) {
-    ref.current?.showModal()
-  } else {
-    ref.current?.close()
-  }
 
   function leggTilEkskluderteIPen() {
     const sakIder = saksnummerToAddListe
@@ -133,13 +126,12 @@ export function EkskluderingLeggTilInputBox(props: { text: string; showModal: bo
   }
 
   return (
-    <div>
-      <Modal
-        ref={ref}
-        header={{ heading: 'Modifiser ekskluderingsliste', closeButton: false }}
-        onClose={props.onCancel}
-      >
-        <Modal.Body>
+    <Dialog open={props.open} onOpenChange={(open) => !open && props.onCancel()}>
+      <Dialog.Popup>
+        <Dialog.Header>
+          <Dialog.Title>Modifiser ekskluderingsliste</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
           <VStack gap={'space-20'}>
             {props.text}
             {(!harLagtTilSaker || response?.erOppdatert) && (
@@ -164,9 +156,8 @@ export function EkskluderingLeggTilInputBox(props: { text: string; showModal: bo
               resize
             />
           </VStack>
-        </Modal.Body>
-
-        <Modal.Footer>
+        </Dialog.Body>
+        <Dialog.Footer>
           <Button
             type="button"
             onClick={() => {
@@ -177,27 +168,22 @@ export function EkskluderingLeggTilInputBox(props: { text: string; showModal: bo
           >
             Legg til
           </Button>
-          <Button type="button" variant="secondary" onClick={props.onCancel} size="small">
-            Lukk
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    </div>
+          <Dialog.CloseTrigger>
+            <Button type="button" variant="secondary" size="small">
+              Lukk
+            </Button>
+          </Dialog.CloseTrigger>
+        </Dialog.Footer>
+      </Dialog.Popup>
+    </Dialog>
   )
 }
 
-export function EkskluderingFjernInputBox(props: { text: string; showModal: boolean; onCancel: () => void }) {
-  const ref = useRef<HTMLDialogElement>(null)
+export function EkskluderingFjernInputBox(props: { text: string; open: boolean; onCancel: () => void }) {
   const fetcher = useFetcher()
   const [saksnummerToRemoveListe, setSaksnummerToRemoveListe] = useState('')
   const response = fetcher.data as OppdaterEksluderteSakerResponse | undefined
   const [harFjernetSaker, setHarFjernetSaker] = useState(false)
-
-  if (props.showModal) {
-    ref.current?.showModal()
-  } else {
-    ref.current?.close()
-  }
 
   function fjernEkskluderteFraPen() {
     const sakIder = saksnummerToRemoveListe
@@ -221,13 +207,12 @@ export function EkskluderingFjernInputBox(props: { text: string; showModal: bool
   }
 
   return (
-    <div>
-      <Modal
-        ref={ref}
-        header={{ heading: 'Modifiser ekskluderingsliste', closeButton: false }}
-        onClose={props.onCancel}
-      >
-        <Modal.Body>
+    <Dialog open={props.open} onOpenChange={(open) => !open && props.onCancel()}>
+      <Dialog.Popup>
+        <Dialog.Header>
+          <Dialog.Title>Modifiser ekskluderingsliste</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
           <VStack gap={'space-20'}>
             {props.text}
             {(!harFjernetSaker || response?.erOppdatert) && (
@@ -244,9 +229,8 @@ export function EkskluderingFjernInputBox(props: { text: string; showModal: bool
               resize
             />
           </VStack>
-        </Modal.Body>
-
-        <Modal.Footer>
+        </Dialog.Body>
+        <Dialog.Footer>
           <Button
             type="button"
             onClick={() => {
@@ -257,12 +241,14 @@ export function EkskluderingFjernInputBox(props: { text: string; showModal: bool
           >
             Fjern
           </Button>
-          <Button type="button" variant="secondary" onClick={props.onCancel} size="small">
-            Lukk
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    </div>
+          <Dialog.CloseTrigger>
+            <Button type="button" variant="secondary" size="small">
+              Lukk
+            </Button>
+          </Dialog.CloseTrigger>
+        </Dialog.Footer>
+      </Dialog.Popup>
+    </Dialog>
   )
 }
 

--- a/app/uforetrygd/vedlikehold-barn.tsx
+++ b/app/uforetrygd/vedlikehold-barn.tsx
@@ -3,9 +3,9 @@ import {
   BodyShort,
   Button,
   Checkbox,
+  Dialog,
   Heading,
   HStack,
-  Modal,
   Table,
   TextField,
   VStack,
@@ -190,18 +190,25 @@ interface LagreOgSendInnModalProps {
 
 function LagreOgSendInnModal({ lagre, avbryt, åpen }: LagreOgSendInnModalProps) {
   return (
-    <Modal open={åpen} onClose={avbryt} header={{ heading: 'Er du sikker?', closeButton: false }}>
-      <Modal.Body>
-        <BodyLong>Endringer kan påvirke brukers ytelse eller gi inkonsistent datagrunnlag.</BodyLong>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button type="button" onClick={lagre}>
-          Lagre
-        </Button>
-        <Button type="button" variant="secondary" onClick={avbryt}>
-          Avbryt
-        </Button>
-      </Modal.Footer>
-    </Modal>
+    <Dialog open={åpen} onOpenChange={(open) => !open && avbryt()}>
+      <Dialog.Popup>
+        <Dialog.Header>
+          <Dialog.Title>Er du sikker?</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Body>
+          <BodyLong>Endringer kan påvirke brukers ytelse eller gi inkonsistent datagrunnlag.</BodyLong>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button type="button" onClick={lagre}>
+            Lagre
+          </Button>
+          <Dialog.CloseTrigger>
+            <Button type="button" variant="secondary">
+              Avbryt
+            </Button>
+          </Dialog.CloseTrigger>
+        </Dialog.Footer>
+      </Dialog.Popup>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Hva
Migrerer 4 route-filer (5 modale) fra `Modal` til `Dialog` (Aksel 8).

## Endrede filer

| Fil | Endring |
|-----|---------|
| `kontroll-saerskilt-sats._index.tsx` | `useRef` → kontrollert `open` state |
| `kontroll-afp-stat-etter-65._index.tsx` | `useRef` → kontrollert `open` state, `useEffect` for close |
| `batch.regulering.ekskludertesaker.tsx` | 2 modale (LeggTil/Fjern): `ref/showModal` → `open/onOpenChange` |
| `vedlikehold-barn.tsx` | LagreOgSendInnModal: `Modal` → `Dialog` |

### Mapping
- `Modal header={{ heading }}` → `Dialog.Title`
- `Modal.Body` → innhold i `Dialog.Popup`
- `Modal.Footer` → `Dialog.Footer`
- Lukk/Avbryt → `Dialog.CloseTrigger`
- `showModal` prop → `open` prop

## Batch 3 av 3
Etter merge av alle 3 batch-PRer (#466, #467, denne) er all `Modal`-bruk migrert til `Dialog`.