### PR TITLE
Fiks: Fjern duplikate rader i brevbestillingsoversikten

### DIFF
--- a/app/brev-bestilling/index.test.ts
+++ b/app/brev-bestilling/index.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import type { AutoBrevOppsummering } from './index'
+import { brevRowKey, mergeRows } from './mergeRows'
+
+const row = (
+  behandlingstype: string,
+  brevkode: string,
+  brevnavn: string | null,
+  sprakKode: string | null,
+  antall: number,
+  brevType: 'BREVBAKER' | 'LEGACY' = 'BREVBAKER',
+): AutoBrevOppsummering => ({
+  behandlingstype,
+  brevkode,
+  originalBrevkode: brevkode,
+  brevnavn,
+  sprakKode,
+  antall,
+  brevType,
+})
+
+describe('mergeRows', () => {
+  it('slår sammen rader med ulik sprakKode', () => {
+    const rows = [
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NB', 100),
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NN', 30),
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].antall).toBe(130)
+    expect(result[0].brevkode).toBe('PE_AP_04_001')
+  })
+
+  it('slår sammen rader med ulik originalBrevkode men lik normalisert brevkode', () => {
+    const rows: AutoBrevOppsummering[] = [
+      {
+        ...row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NB', 50),
+        originalBrevkode: 'AP_INNVILGELSE_AUTO',
+      },
+      {
+        ...row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NB', 20),
+        originalBrevkode: 'AP_INNVILGELSE_V2',
+      },
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].antall).toBe(70)
+  })
+
+  it('beholder rader med ulik behandlingstype som separate', () => {
+    const rows = [
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NB', 100),
+      row('DodsmeldingBehandling', 'PE_AP_04_001', 'Vedtak - innvilgelse', 'NB', 40),
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('beholder rader med ulik brevType som separate', () => {
+    const rows = [
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak', 'NB', 100, 'BREVBAKER'),
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'Vedtak', 'NB', 25, 'LEGACY'),
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('håndterer null brevnavn uten kollisjoner', () => {
+    const rows = [
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', null, 'NB', 60),
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', null, 'NN', 40),
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].antall).toBe(100)
+    expect(result[0].brevnavn).toBeNull()
+  })
+
+  it('skiller rader der brevnavn er null fra rader med brevnavn "null"', () => {
+    const rows = [
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', null, 'NB', 10),
+      row('FleksibelApSakBehandling', 'PE_AP_04_001', 'null', 'NB', 5),
+    ]
+
+    const result = mergeRows(rows)
+
+    expect(result).toHaveLength(2)
+    expect(result.find((r) => r.brevnavn === null)?.antall).toBe(10)
+    expect(result.find((r) => r.brevnavn === 'null')?.antall).toBe(5)
+  })
+
+  it('returnerer tom liste for tom input', () => {
+    expect(mergeRows([])).toEqual([])
+  })
+})
+
+describe('brevRowKey', () => {
+  it('gir lik nøkkel for rader som bare skiller seg på sprakKode', () => {
+    const a = row('Behandling', 'KODE', 'Navn', 'NB', 1)
+    const b = row('Behandling', 'KODE', 'Navn', 'NN', 2)
+
+    expect(brevRowKey(a)).toBe(brevRowKey(b))
+  })
+
+  it('gir ulik nøkkel for rader med ulik brevType', () => {
+    const a = row('Behandling', 'KODE', 'Navn', 'NB', 1, 'BREVBAKER')
+    const b = row('Behandling', 'KODE', 'Navn', 'NB', 1, 'LEGACY')
+
+    expect(brevRowKey(a)).not.toBe(brevRowKey(b))
+  })
+})

--- a/app/brev-bestilling/index.tsx
+++ b/app/brev-bestilling/index.tsx
@@ -24,6 +24,7 @@ import { toIsoDate } from '~/common/date'
 import { decodeBehandling } from '~/common/decodeBehandling'
 import { apiGet } from '~/services/api.server'
 import type { Route } from './+types/index'
+import { brevRowKey, mergeRows } from './mergeRows'
 
 /** DTO som speiler API-responsen fra /api/behandling/brev/oppsummering */
 type AutoBrevOppsummeringDto = {
@@ -94,7 +95,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   qs.set('tomDato', tomDato)
 
   const dtoRows = await apiGet<AutoBrevOppsummeringDto[]>(`/api/behandling/brev/oppsummering?${qs.toString()}`, request)
-  const rows: AutoBrevOppsummering[] = dtoRows.map((r) => ({
+  const mapped: AutoBrevOppsummering[] = dtoRows.map((r) => ({
     behandlingstype: r.behandlingstype,
     brevkode: r.brevbakerBrevkode ?? r.brevkode,
     originalBrevkode: r.brevkode,
@@ -104,6 +105,9 @@ export async function loader({ request }: Route.LoaderArgs) {
     brevType: r.brevType,
   }))
 
+  // Slå sammen rader som er visuelt like (f.eks. ulike språkkoder for samme brev)
+  const rows = mergeRows(mapped)
+
   return {
     rows,
     nowIso: now.toISOString(),
@@ -112,8 +116,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 }
 
-/** Sentinel-verdi for null i URL-parametere */
+/** Sentinel-verdi for null i URL-parametere og sammensatte nøkler */
 const NULL_TOKEN = '__NULL__'
+const KEY_SEP = '\u001F'
 
 function encodeValue(v: string | null): string {
   return v ?? NULL_TOKEN
@@ -177,7 +182,6 @@ type GroupRow = {
 
 function groupRows(rows: AutoBrevOppsummering[], keys: FacetKey[]): GroupRow[] {
   if (!keys.length) return []
-  const sep = '\u001F'
   const m = new Map<string, GroupRow>()
   for (const r of rows) {
     const rawValues: Partial<Record<FacetKey, string | null>> = {}
@@ -186,7 +190,7 @@ function groupRows(rows: AutoBrevOppsummering[], keys: FacetKey[]): GroupRow[] {
       rawValues[k] = r[k] ?? null
       labels[k] = labelForFacet(k, r)
     }
-    const key = keys.map((k) => encodeValue(rawValues[k] ?? null)).join(sep)
+    const key = keys.map((k) => encodeValue(rawValues[k] ?? null)).join(KEY_SEP)
     const prev = m.get(key)
     if (prev) {
       prev.antall += r.antall
@@ -216,7 +220,7 @@ function toggleParam(current: string[] | null, value: string): string[] | null {
   return arr.length ? arr : null
 }
 
-const rowKey = (r: AutoBrevOppsummering) => [r.behandlingstype, r.originalBrevkode, r.brevnavn, r.sprakKode].join('|')
+const rowKey = brevRowKey
 
 function countActiveFilters(filters: Partial<Record<FacetKey, string[]>>): number {
   return Object.values(filters).reduce((acc, v) => acc + ((v?.length ?? 0) > 0 ? 1 : 0), 0)

--- a/app/brev-bestilling/mergeRows.ts
+++ b/app/brev-bestilling/mergeRows.ts
@@ -1,0 +1,28 @@
+import type { AutoBrevOppsummering } from './index'
+
+const NULL_TOKEN = '__NULL__'
+const KEY_SEP = '\u001F'
+
+function encodeValue(v: string | null): string {
+  return v ?? NULL_TOKEN
+}
+
+/** Nøkkel som identifiserer visuelt like rader — brukes for sammenslåing og som React key */
+export function brevRowKey(r: AutoBrevOppsummering): string {
+  return [r.behandlingstype, r.brevkode, r.brevnavn, r.brevType].map((v) => encodeValue(v ?? null)).join(KEY_SEP)
+}
+
+/** Slår sammen rader med lik visuell identitet og summerer antall */
+export function mergeRows(rows: AutoBrevOppsummering[]): AutoBrevOppsummering[] {
+  const merged = new Map<string, AutoBrevOppsummering>()
+  for (const r of rows) {
+    const key = brevRowKey(r)
+    const existing = merged.get(key)
+    if (existing) {
+      existing.antall += r.antall
+    } else {
+      merged.set(key, { ...r })
+    }
+  }
+  return [...merged.values()]
+}


### PR DESCRIPTION
Backend kan returnere flere rader for samme brev (f.eks. ulike språkkoder), som førte til at visuelt identiske rader dukket opp flere ganger i tabellen.

Endringer:
- Slår sammen rader med samme behandlingstype, brevkode, brevnavn og brevType i loaderen, og summerer antall
- Oppdaterer rowKey til å bruke normalisert brevkode i stedet for originalBrevkode