### PR TITLE
Lenk Feilende-card på dashboard til /behandlinger/FEILENDE

### DIFF
--- a/app/components/dashboard-card/DashboardCard.stories.tsx
+++ b/app/components/dashboard-card/DashboardCard.stories.tsx
@@ -1,5 +1,6 @@
 import { BriefcaseIcon, BugIcon, ClockDashedIcon } from '@navikt/aksel-icons'
 import type { Meta, StoryObj } from '@storybook/react'
+import { withRouter } from '../../../.storybook/mocks/router'
 import { DashboardCard } from './DashboardCard'
 
 const meta = {
@@ -20,11 +21,13 @@ export const Default: Story = {
 }
 
 export const Feilende: Story = {
+  decorators: [withRouter],
   args: {
     title: 'Feilende behandlinger',
     value: '3',
     iconBackgroundColor: 'var(--ax-bg-danger-moderate)',
     icon: BugIcon,
+    href: '/behandlinger/FEILENDE',
   },
 }
 

--- a/app/components/dashboard-card/DashboardCard.tsx
+++ b/app/components/dashboard-card/DashboardCard.tsx
@@ -1,6 +1,7 @@
 import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react'
 import type { Property } from 'csstype'
 import type React from 'react'
+import { Link } from 'react-router'
 
 interface SVGRProps {
   title?: string
@@ -12,10 +13,11 @@ type Props = {
   value: string
   iconBackgroundColor: Property.BackgroundColor
   icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & SVGRProps & React.RefAttributes<SVGSVGElement>>
+  href?: string
 }
 
 export function DashboardCard(props: Props) {
-  return (
+  const card = (
     <Box background={'raised'} borderRadius="4" shadow="dialog" style={{ padding: '12px 16px' }}>
       <HStack gap="space-16" align="center">
         <Box
@@ -49,4 +51,14 @@ export function DashboardCard(props: Props) {
       </HStack>
     </Box>
   )
+
+  if (props.href) {
+    return (
+      <Link to={props.href} style={{ textDecoration: 'none', color: 'inherit' }}>
+        {card}
+      </Link>
+    )
+  }
+
+  return card
 }

--- a/app/dashboard/route.tsx
+++ b/app/dashboard/route.tsx
@@ -115,6 +115,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
                     title="Feilende"
                     value={formatNumber(dashboardResponse.feilendeBehandlinger)}
                     icon={ExclamationmarkTriangleFillIcon}
+                    href="/behandlinger/FEILENDE"
                   />
                   <DashboardCard
                     iconBackgroundColor={'var(--ax-bg-warning-strong)'}


### PR DESCRIPTION
## Endring
Feilende-cardet på dashboard er nå klikkbart og navigerer til `/behandlinger/FEILENDE`.

### Hva er gjort
- La til valgfri `href`-prop på `DashboardCard`-komponenten
- Når `href` er satt, wrappes cardet i en React Router `<Link>`
- Satt `href="/behandlinger/FEILENDE"` på Feilende-cardet på dashboard
- Oppdatert Storybook-story