### PR TITLE
Lenk dashboard-kort til behandlinger/antall med støtte for kun ukjente typer

### DIFF
--- a/app/behandlinger/behandlinger.antall.stories.tsx
+++ b/app/behandlinger/behandlinger.antall.stories.tsx
@@ -10,14 +10,26 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj
 
+const behandlingAntall = [
+  { navn: 'Førstegangsbehandling Alder', behandlingType: 'ForstegangsbehandlingAlder', antall: 42 },
+  { navn: 'Omregning', behandlingType: 'Omregning', antall: 128 },
+  { navn: 'Regulering', behandlingType: 'Regulering', antall: 15 },
+  { navn: 'GammelType', behandlingType: null, antall: 5 },
+]
+
 export const Default: Story = {
   render: () =>
     renderWithLoader(BehandlingerAntall, {
-      behandlingAntall: [
-        { navn: 'Førstegangsbehandling Alder', behandlingType: 'ForstegangsbehandlingAlder', antall: 42 },
-        { navn: 'Omregning', behandlingType: 'Omregning', antall: 128 },
-        { navn: 'Regulering', behandlingType: 'Regulering', antall: 15 },
-      ],
+      behandlingAntall,
+      kunUkjente: false,
+    }),
+}
+
+export const KunUkjente: Story = {
+  render: () =>
+    renderWithLoader(BehandlingerAntall, {
+      behandlingAntall,
+      kunUkjente: true,
     }),
 }
 
@@ -25,5 +37,6 @@ export const Empty: Story = {
   render: () =>
     renderWithLoader(BehandlingerAntall, {
       behandlingAntall: [],
+      kunUkjente: false,
     }),
 }

--- a/app/behandlinger/behandlinger.antall.tsx
+++ b/app/behandlinger/behandlinger.antall.tsx
@@ -3,18 +3,28 @@ import { apiGet } from '~/services/api.server'
 import type { BehandlingAntallResponse } from '~/types'
 import type { Route } from './+types/behandlinger.antall'
 
-export function meta(): Route.MetaDescriptors {
-  return [{ title: 'Antall behandlinger | Verdande' }]
+export function meta({ loaderData }: Route.MetaArgs): Route.MetaDescriptors {
+  const prefix = loaderData.kunUkjente ? 'Ukjente behandlingstyper' : 'Antall behandlinger'
+  return [{ title: `${prefix} | Verdande` }]
 }
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
+  const url = new URL(request.url)
+  const kunUkjente = url.searchParams.get('kunUkjente') === 'true'
+
   const { behandlingAntall } = await apiGet<BehandlingAntallResponse>(
     '/api/behandling/oppsummering-behandling-antall',
     request,
   )
-  return { behandlingAntall }
+  return { behandlingAntall, kunUkjente }
 }
 
 export default function BehandlingerAntall({ loaderData }: Route.ComponentProps) {
-  return <BehandlingAntallTableCard behandlingAntall={loaderData.behandlingAntall} />
+  return (
+    <BehandlingAntallTableCard
+      behandlingAntall={loaderData.behandlingAntall}
+      defaultVisAlle
+      kunUkjente={loaderData.kunUkjente}
+    />
+  )
 }

--- a/app/components/behandling-antall-table/BehandlingAntallTable.tsx
+++ b/app/components/behandling-antall-table/BehandlingAntallTable.tsx
@@ -10,15 +10,20 @@ const DEFAULT_VISIBLE_ROWS = 10
 
 type Props = {
   oppsummering: BehandlingAntall[]
+  defaultVisAlle?: boolean
+  kunUkjente?: boolean
 }
 
 export default function BehandlingAntallTable(props: Props) {
   const { sortFunc } = useSort<BehandlingAntall>('antall')
-  const [visAlle, setVisAlle] = useState(false)
+  const [visAlle, setVisAlle] = useState(props.defaultVisAlle ?? false)
 
   const sortedOppsummering: BehandlingAntall[] = React.useMemo(() => {
-    return props.oppsummering.slice().sort(sortFunc)
-  }, [props.oppsummering, sortFunc])
+    const filtered = props.kunUkjente
+      ? props.oppsummering.filter((it) => it.behandlingType === null)
+      : props.oppsummering
+    return filtered.slice().sort(sortFunc)
+  }, [props.oppsummering, props.kunUkjente, sortFunc])
 
   const harFlereEnnDefault = sortedOppsummering.length > DEFAULT_VISIBLE_ROWS
   const synligeRader = visAlle ? sortedOppsummering : sortedOppsummering.slice(0, DEFAULT_VISIBLE_ROWS)

--- a/app/components/behandling-antall-table/BehandlingAntallTableCard.tsx
+++ b/app/components/behandling-antall-table/BehandlingAntallTableCard.tsx
@@ -5,6 +5,8 @@ import type { BehandlingAntall } from '~/types'
 
 type Props = {
   behandlingAntall: BehandlingAntall[]
+  defaultVisAlle?: boolean
+  kunUkjente?: boolean
 }
 
 export function BehandlingAntallTableCard(props: Props) {
@@ -17,10 +19,14 @@ export function BehandlingAntallTableCard(props: Props) {
             fontSize="1.5rem"
             style={{ verticalAlign: 'middle', marginRight: '6px' }}
           />
-          Antall etter type
+          {props.kunUkjente ? 'Ukjente behandlingstyper' : 'Antall etter type'}
         </div>
       </Box>
-      <BehandlingAntallTable oppsummering={props.behandlingAntall} />
+      <BehandlingAntallTable
+        oppsummering={props.behandlingAntall}
+        defaultVisAlle={props.defaultVisAlle}
+        kunUkjente={props.kunUkjente}
+      />
     </Box>
   )
 }

--- a/app/dashboard/route.tsx
+++ b/app/dashboard/route.tsx
@@ -103,6 +103,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
                     title="Totalt"
                     value={formatNumber(dashboardResponse.totaltAntallBehandlinger)}
                     icon={ClipboardFillIcon}
+                    href="/behandlinger/antall"
                   />
                   <DashboardCard
                     iconBackgroundColor={'var(--ax-bg-accent-strong)'}
@@ -122,6 +123,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
                     title="Ukjente typer"
                     value={formatNumber(dashboardResponse.ukjenteBehandlingstyper.length)}
                     icon={QuestionmarkDiamondFillIcon}
+                    href="/behandlinger/antall?kunUkjente=true"
                   />
                 </HGrid>
                 <HGrid gap="space-24" columns={2}>


### PR DESCRIPTION
## Endring
- **Totalt**-kortet på dashboard lenker nå til `/behandlinger/antall`
- **Ukjente typer**-kortet lenker til `/behandlinger/antall?kunUkjente=true`
- `/behandlinger/antall` viser nå alle rader som default (ikke begrenset til topp 10)
- Ny `?kunUkjente=true` query-param filtrerer til kun ukjente behandlingstyper

### Endrede filer
- `app/dashboard/route.tsx` — href på Totalt og Ukjente typer-kort
- `app/behandlinger/behandlinger.antall.tsx` — leser `kunUkjente` param, defaultVisAlle
- `app/components/behandling-antall-table/BehandlingAntallTable.tsx` — `defaultVisAlle` og `kunUkjente` props
- `app/components/behandling-antall-table/BehandlingAntallTableCard.tsx` — videreformidler props, dynamisk tittel
- `app/behandlinger/behandlinger.antall.stories.tsx` — ny KunUkjente story