### PR TITLE
Visuell flair på klikkbare dashboard-kort

### DIFF
--- a/app/components/dashboard-card/DashboardCard.module.css
+++ b/app/components/dashboard-card/DashboardCard.module.css
@@ -1,0 +1,16 @@
+.clickable {
+  display: block;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--ax-border-radius-4);
+  transition:
+    box-shadow 150ms ease,
+    transform 150ms ease;
+}
+
+.clickable:hover,
+.clickable:focus-visible {
+  box-shadow: var(--ax-shadow-large);
+  transform: translateY(-2px);
+}

--- a/app/components/dashboard-card/DashboardCard.stories.tsx
+++ b/app/components/dashboard-card/DashboardCard.stories.tsx
@@ -20,6 +20,17 @@ export const Default: Story = {
   },
 }
 
+export const Klikkbar: Story = {
+  decorators: [withRouter],
+  args: {
+    title: 'Totalt antall behandlinger',
+    value: '185',
+    iconBackgroundColor: 'var(--ax-bg-brand-blue-moderate)',
+    icon: BriefcaseIcon,
+    href: '/behandlinger/antall',
+  },
+}
+
 export const Feilende: Story = {
   decorators: [withRouter],
   args: {

--- a/app/components/dashboard-card/DashboardCard.tsx
+++ b/app/components/dashboard-card/DashboardCard.tsx
@@ -1,7 +1,9 @@
+import { ChevronRightIcon } from '@navikt/aksel-icons'
 import { BodyShort, Box, Heading, HStack, VStack } from '@navikt/ds-react'
 import type { Property } from 'csstype'
 import type React from 'react'
 import { Link } from 'react-router'
+import styles from './DashboardCard.module.css'
 
 interface SVGRProps {
   title?: string
@@ -48,13 +50,20 @@ export function DashboardCard(props: Props) {
             {props.value}
           </Heading>
         </VStack>
+        {props.href && (
+          <ChevronRightIcon
+            aria-hidden
+            fontSize="1.5rem"
+            style={{ marginLeft: 'auto', color: 'var(--ax-text-subtle)' }}
+          />
+        )}
       </HStack>
     </Box>
   )
 
   if (props.href) {
     return (
-      <Link to={props.href} style={{ textDecoration: 'none', color: 'inherit' }}>
+      <Link to={props.href} className={styles.clickable}>
         {card}
       </Link>
     )


### PR DESCRIPTION
## Endring
Gjør det lettere å forstå at dashboard-kortene er klikkbare.

### Hva er lagt til
- **Hover-effekt**: `cursor: pointer`, løft (`translateY(-2px)`) og skygge via `var(--ax-shadow-large)` ved hover
- **Focus-visible**: Samme visuelle effekt ved keyboard-navigasjon (`Tab`)
- **ChevronRightIcon** (→) til høyre på klikkbare kort — synlig hint uten interaksjon
- `clickable`-klassen ligger på `<Link>` (ikke `<Box>`) for korrekt fokushåndtering
- Ny CSS-modul `DashboardCard.module.css` for hover/focus-states
- Ny `Klikkbar` story i Storybook

### Filer
- `app/components/dashboard-card/DashboardCard.tsx` — chevron + className på Link
- `app/components/dashboard-card/DashboardCard.module.css` — ny fil
- `app/components/dashboard-card/DashboardCard.stories.tsx` — ny Klikkbar story