### PR TITLE
Legg til rød sirkel rundt dagens dato i kalenderen

### DIFF
--- a/app/components/kalender/Dag.module.css
+++ b/app/components/kalender/Dag.module.css
@@ -1,0 +1,20 @@
+.todayWrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+}
+
+.todayCircle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--ax-bg-danger-strong);
+  color: var(--ax-text-danger-contrast);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 1;
+  flex-shrink: 0;
+}

--- a/app/components/kalender/Dag.tsx
+++ b/app/components/kalender/Dag.tsx
@@ -6,9 +6,11 @@ import { isSameDay } from '~/common/date'
 import { decodeBehandling } from '~/common/decodeBehandling'
 import { getWeek } from '~/common/weeknumber'
 import type { KalenderBehandling, KalenderHendelser } from '~/components/kalender/types'
+import styles from './Dag.module.css'
 
 export type Props = {
   dato: Date
+  iDag: Date
   highlightMaaned: Date
   maksAntallPerDag?: number
   kalenderHendelser: KalenderHendelser
@@ -28,15 +30,16 @@ export default function Dag(props: Props) {
     dagStreng = `${props.dato.getDate().toString()}.`
   }
 
+  const erIDag = isSameDay(props.dato, props.iDag)
+
   let dagLabel: JSX.Element
-  if (isSameDay(props.dato, new Date())) {
+  if (erIDag) {
+    const maanedSuffix =
+      props.dato.getDate() === 1 ? ` ${props.dato.toLocaleDateString('no-NO', { month: 'short' })}` : ''
     dagLabel = (
-      <span
-        style={{
-          fontWeight: 'bold',
-        }}
-      >
-        {dagStreng}
+      <span className={styles.todayWrapper}>
+        <span className={styles.todayCircle}>{props.dato.getDate()}</span>
+        <span>.{maanedSuffix}</span>
       </span>
     )
   } else {

--- a/app/components/kalender/Kalender.tsx
+++ b/app/components/kalender/Kalender.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons'
 import { Box, Button, Heading, HStack, Spacer } from '@navikt/ds-react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import { erHelgedag, getDato, isSameDay } from '~/common/date'
 import { getWeek, getWeekYear } from '~/common/weeknumber'
@@ -26,6 +27,7 @@ export type Props = {
   maksAntallPerDag: number
   startDato: Date
   visKlokkeSlett: boolean
+  serverIDag?: string
 }
 
 function backgroundColorForDato(kalenderHendelser: KalenderHendelser, dato: Date): string {
@@ -41,6 +43,37 @@ export default function Kalender(props: Props) {
   const [, setSearchParams] = useSearchParams()
   const firstInThisMonth = new Date(valgtDato.getFullYear(), valgtDato.getMonth(), 1)
   const forsteUkeNr = getWeek(firstInThisMonth)
+
+  // Parse YYYY-MM-DD som lokal midnatt (ikke UTC) for konsistent datosammenligning
+  function parseLokalDato(isoStr: string): Date {
+    const [y, m, d] = isoStr.split('-').map(Number)
+    return new Date(y, m - 1, d)
+  }
+
+  // Bruk server-datoen som initial verdi for å unngå hydreringsfeil,
+  // og oppdater ved midnatt slik at sirkelen flyttes til riktig dag.
+  const [iDagDato, setIDagDato] = useState(() => (props.serverIDag ? parseLokalDato(props.serverIDag) : new Date()))
+
+  useEffect(() => {
+    let timerRef: ReturnType<typeof setTimeout>
+
+    function planleggMidnattOppdatering() {
+      const naa = new Date()
+      const nesteMidnatt = new Date(naa.getFullYear(), naa.getMonth(), naa.getDate() + 1)
+      const msTilMidnatt = nesteMidnatt.getTime() - naa.getTime() + 100 // +100ms margin
+
+      timerRef = setTimeout(() => {
+        setIDagDato(new Date())
+        planleggMidnattOppdatering()
+      }, msTilMidnatt)
+    }
+
+    // Synk med klient-tid etter hydring
+    setIDagDato(new Date())
+    planleggMidnattOppdatering()
+
+    return () => clearTimeout(timerRef)
+  }, [])
 
   function day(ukenr: number, colIdx: number) {
     return getDato(getWeekYear(valgtDato), ukenr, colIdx + 1)
@@ -81,6 +114,7 @@ export default function Kalender(props: Props) {
       >
         <Dag
           dato={dato}
+          iDag={iDagDato}
           highlightMaaned={valgtDato}
           kalenderHendelser={props.kalenderHendelser}
           maksAntallPerDag={props.maksAntallPerDag}

--- a/app/kalender/route.tsx
+++ b/app/kalender/route.tsx
@@ -1,3 +1,4 @@
+import { asLocalDateString } from '~/common/date'
 import Kalender, { forsteOgSisteDatoForKalender } from '~/components/kalender/Kalender'
 import { hentKalenderHendelser } from '~/services/behandling.server'
 import type { Route } from './+types/route'
@@ -21,11 +22,12 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       tom: sisteDato,
     }),
     startDato: startDato,
+    serverIDag: asLocalDateString(new Date()),
   }
 }
 
 export default function KalenderVisning({ loaderData }: Route.ComponentProps) {
-  const { kalenderHendelser, startDato } = loaderData
+  const { kalenderHendelser, startDato, serverIDag } = loaderData
 
   return (
     <Kalender
@@ -33,6 +35,7 @@ export default function KalenderVisning({ loaderData }: Route.ComponentProps) {
       maksAntallPerDag={6}
       startDato={startDato}
       visKlokkeSlett={true}
+      serverIDag={serverIDag}
     ></Kalender>
   )
 }


### PR DESCRIPTION
Viser dagens dato med en rød sirkel (à la macOS-kalenderen) slik at det er lettere å se hvilken dag det er. Tallet vises i sirkelen, med punktum utenfor. Styles i Dag.module.css.

Unngår hydreringsfeil ved å sende serverIDag fra loader og bruke den som initial state. Etter hydring synkes med klient-tid, og en timer sørger for at sirkelen flyttes ved midnatt.

Bruker Aksel tokens for farge:
- --ax-bg-danger-strong (rød bakgrunn)
- --ax-text-danger-contrast (hvit tekst)

<img width="2168" height="1402" alt="Skjermbilde 2026-04-18 kl  14 56 25" src="https://github.com/user-attachments/assets/246dbbde-458c-4d73-837c-57411736058d" />
