### PR TITLE
Alderspensjon-mottakere: UI for tilvekst og avgang

### DIFF
--- a/app/analyse/alderspensjon-index.tsx
+++ b/app/analyse/alderspensjon-index.tsx
@@ -1,0 +1,7 @@
+import { redirect } from 'react-router'
+import type { Route } from './+types/alderspensjon-index'
+
+export function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url)
+  throw redirect(`/analyse/alderspensjon/mottakere${url.search}`)
+}

--- a/app/analyse/alderspensjon-layout.tsx
+++ b/app/analyse/alderspensjon-layout.tsx
@@ -1,0 +1,184 @@
+import {
+  BodyShort,
+  Box,
+  Button,
+  DatePicker,
+  Detail,
+  Heading,
+  HStack,
+  Label,
+  Select,
+  useRangeDatepicker,
+  VStack,
+} from '@navikt/ds-react'
+import { sub } from 'date-fns'
+import React from 'react'
+import { useSearchParams } from 'react-router'
+import type { DateRange } from '~/behandlingserie/seriekalenderUtils'
+import { toIsoDate } from '~/common/date'
+import type { Route } from './+types/alderspensjon-layout'
+import SectionTabLayout from './SectionTabLayout'
+import { formaterTimestamp, normalizePeriodToDate } from './utils/formattering'
+import { parseAlderspensjonParams } from './utils/parseAlderspensjonParams'
+
+const faner = [{ value: 'mottakere', label: 'Mottakere' }] as const
+
+/**
+ * Velg passende aggregeringsnivå for alderspensjon-mottakere ut fra periodelengde.
+ * Endepunktet støtter DAG, UKE, MAANED, KVARTAL og AAR. MAANED er primær bruk.
+ */
+function velgAggregering(fom: string, tom: string): string {
+  const diffDays = (new Date(tom).getTime() - new Date(fom).getTime()) / (1000 * 60 * 60 * 24)
+  if (diffDays <= 31) return 'DAG'
+  if (diffDays <= 180) return 'UKE'
+  if (diffDays <= 1825) return 'MAANED'
+  if (diffDays <= 3650) return 'KVARTAL'
+  return 'AAR'
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const { fom, tom, aggregering } = parseAlderspensjonParams(request)
+  return { fom, tom, aggregering }
+}
+
+export function shouldRevalidate({ currentUrl, nextUrl }: { currentUrl: URL; nextUrl: URL }) {
+  return currentUrl.search !== nextUrl.search
+}
+
+export default function AlderspensjonLayout({ loaderData }: Route.ComponentProps) {
+  const { fom, tom, aggregering } = loaderData
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  function updateSearchParams(updates: Record<string, string>) {
+    const next = new URLSearchParams(searchParams)
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) next.set(key, value)
+      else next.delete(key)
+    }
+    setSearchParams(next)
+  }
+
+  function onRangeChange(val?: DateRange) {
+    if (val?.from && val.to) {
+      const newFom = toIsoDate(val.from)
+      const newTom = toIsoDate(val.to)
+      const currentFomDate = (searchParams.get('fom') || '').split('T')[0]
+      const currentTomDate = (searchParams.get('tom') || '').split('T')[0]
+      if (newFom !== currentFomDate || newTom !== currentTomDate) {
+        updateSearchParams({ fom: newFom, tom: newTom })
+      }
+    }
+  }
+
+  const { datepickerProps, fromInputProps, toInputProps, setSelected } = useRangeDatepicker({
+    defaultSelected: { from: new Date(fom), to: new Date(tom) },
+    required: true,
+    onRangeChange,
+  })
+
+  const setSelectedRef = React.useRef(setSelected)
+  setSelectedRef.current = setSelected
+  const prevFomTom = React.useRef(`${fom}|${tom}`)
+  React.useEffect(() => {
+    const key = `${fom}|${tom}`
+    if (key !== prevFomTom.current) {
+      prevFomTom.current = key
+      setSelectedRef.current({ from: new Date(fom.split('T')[0]), to: new Date(tom.split('T')[0]) })
+    }
+  }, [fom, tom])
+
+  function applyPeriod(nextFrom: string, nextTo: string, autoAggregering = true) {
+    const fromDate = normalizePeriodToDate(nextFrom, 'start')
+    const toDate = normalizePeriodToDate(nextTo, 'end')
+    setSelectedRef.current({ from: new Date(fromDate), to: new Date(toDate) })
+    const updates: Record<string, string> = { fom: fromDate, tom: toDate }
+    if (autoAggregering) updates.aggregering = velgAggregering(fromDate, toDate)
+    updateSearchParams(updates)
+  }
+
+  function presetLastNMonths(n: number) {
+    const now = new Date()
+    applyPeriod(toIsoDate(sub(now, { months: n })), toIsoDate(now))
+  }
+
+  function presetThisYear() {
+    const now = new Date()
+    applyPeriod(`${now.getFullYear()}-01-01`, toIsoDate(now))
+  }
+
+  function presetAllTime() {
+    applyPeriod('2010-01-01', toIsoDate(new Date()))
+  }
+
+  return (
+    <VStack gap="space-24">
+      <VStack gap="space-8">
+        <Heading level="2" size="medium">
+          Alderspensjon
+        </Heading>
+        <BodyShort size="small" textColor="subtle">
+          Tidsserier for tilvekst og avgang av alderspensjon-mottakere, med snitt utbetaling for nye mottakere. Bruk
+          filtrene under for å velge tidsrom og aggregeringsnivå.
+        </BodyShort>
+      </VStack>
+
+      <Box>
+        <VStack gap="space-16">
+          <Heading level="3" size="small">
+            Søkekriterier
+          </Heading>
+          <HStack gap="space-16" wrap align="end">
+            <DatePicker {...datepickerProps}>
+              <HStack gap="space-16">
+                <DatePicker.Input size="small" {...fromInputProps} label="Fra dato" />
+                <DatePicker.Input size="small" {...toInputProps} label="Til dato" />
+              </HStack>
+            </DatePicker>
+
+            <VStack gap="space-8">
+              <Label size="small">Hurtigvalg</Label>
+              <HStack gap="space-8">
+                <Button size="small" variant="secondary" onClick={() => presetLastNMonths(12)}>
+                  12 mnd
+                </Button>
+                <Button size="small" variant="secondary" onClick={() => presetLastNMonths(24)}>
+                  24 mnd
+                </Button>
+                <Button size="small" variant="secondary" onClick={() => presetLastNMonths(60)}>
+                  5 år
+                </Button>
+                <Button size="small" variant="secondary" onClick={presetThisYear}>
+                  Hittil i år
+                </Button>
+                <Button size="small" variant="secondary" onClick={presetAllTime}>
+                  Hele historikken
+                </Button>
+              </HStack>
+            </VStack>
+
+            <Box style={{ minWidth: '140px' }}>
+              <Select
+                label="Tidsintervall"
+                size="small"
+                value={aggregering}
+                onChange={(e) => updateSearchParams({ aggregering: e.target.value })}
+              >
+                <option value="DAG">Dag</option>
+                <option value="UKE">Uke</option>
+                <option value="MAANED">Måned</option>
+                <option value="KVARTAL">Kvartal</option>
+                <option value="AAR">År</option>
+              </Select>
+            </Box>
+          </HStack>
+        </VStack>
+      </Box>
+
+      <Detail textColor="subtle">
+        Valgt periode: {formaterTimestamp(fom)} – {formaterTimestamp(tom)}
+      </Detail>
+
+      <SectionTabLayout sectionPath="alderspensjon" faner={faner} />
+    </VStack>
+  )
+}

--- a/app/analyse/components/MottakereAlderChart.tsx
+++ b/app/analyse/components/MottakereAlderChart.tsx
@@ -1,0 +1,167 @@
+import { BodyShort, VStack } from '@navikt/ds-react'
+import type { ChartData, ChartOptions } from 'chart.js'
+import {
+  BarController,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { useMemo } from 'react'
+import { Chart } from 'react-chartjs-2'
+import type { AlderspensjonMottakereDatapunkt } from '../types'
+import { formaterPeriodeLabel, formaterTall } from '../utils/formattering'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  LineController,
+  BarController,
+  Title,
+  Tooltip,
+  Legend,
+)
+
+interface Props {
+  data: AlderspensjonMottakereDatapunkt[]
+}
+
+const NYE_COLOR = 'rgba(54, 162, 235, 1)'
+const NYE_BG = 'rgba(54, 162, 235, 0.15)'
+const OPPHOR_COLOR = 'rgba(255, 99, 132, 1)'
+const OPPHOR_BG = 'rgba(255, 99, 132, 0.15)'
+const SNITT_COLOR = 'rgba(75, 192, 75, 0.55)'
+const SNITT_BORDER = 'rgba(75, 192, 75, 1)'
+
+/**
+ * Combo-graf for alderspensjon-mottakere:
+ * - Linjer for antall nye og antall opphør per periode (venstre Y-akse)
+ * - Søyler for snitt månedlig brutto for nye mottakere (høyre Y-akse, NOK)
+ */
+export default function MottakereAlderChart({ data }: Props) {
+  const chart = useMemo(() => {
+    if (data.length === 0) return null
+
+    const sorted = [...data].sort((a, b) => a.periodeFra.localeCompare(b.periodeFra))
+    const labels = sorted.map((d) => d.periodeFra)
+    const pointRadius = sorted.length > 30 ? 0 : 2
+
+    const datasets: ChartData<'bar' | 'line'>['datasets'] = [
+      {
+        type: 'line' as const,
+        label: 'Nye mottakere',
+        data: sorted.map((d) => d.antallNye),
+        borderColor: NYE_COLOR,
+        backgroundColor: NYE_BG,
+        borderWidth: 1.8,
+        tension: 0.3,
+        pointRadius,
+        yAxisID: 'y',
+      },
+      {
+        type: 'line' as const,
+        label: 'Opphør',
+        data: sorted.map((d) => d.antallOpphor),
+        borderColor: OPPHOR_COLOR,
+        backgroundColor: OPPHOR_BG,
+        borderWidth: 1.8,
+        tension: 0.3,
+        pointRadius,
+        yAxisID: 'y',
+      },
+      {
+        type: 'bar' as const,
+        label: 'Snitt brutto/mnd (NOK, nye)',
+        data: sorted.map((d) =>
+          d.gjennomsnittBruttoPerAarNyeMottakere == null ? null : d.gjennomsnittBruttoPerAarNyeMottakere / 12,
+        ),
+        backgroundColor: SNITT_COLOR,
+        borderColor: SNITT_BORDER,
+        borderWidth: 1,
+        yAxisID: 'y1',
+      },
+    ]
+
+    return { labels, datasets } as ChartData<'bar' | 'line'>
+  }, [data])
+
+  const options: ChartOptions<'bar' | 'line'> = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index' as const, intersect: false },
+      plugins: {
+        legend: { display: true, position: 'top' as const },
+        tooltip: {
+          callbacks: {
+            title: (items) => formaterPeriodeLabel(items[0]?.label ?? ''),
+            label: (item) => {
+              const v = item.parsed.y
+              if (v == null) return `${item.dataset.label}: –`
+              if (item.dataset.yAxisID === 'y1') {
+                return `${item.dataset.label}: ${v.toLocaleString('nb-NO', { maximumFractionDigits: 0 })} kr`
+              }
+              return `${item.dataset.label}: ${formaterTall(v)}`
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            callback: function (value) {
+              return formaterPeriodeLabel(this.getLabelForValue(value as number))
+            },
+            maxTicksLimit: 12,
+          },
+        },
+        y: {
+          type: 'linear' as const,
+          position: 'left' as const,
+          beginAtZero: true,
+          title: { display: true, text: 'Antall' },
+        },
+        y1: {
+          type: 'linear' as const,
+          position: 'right' as const,
+          beginAtZero: true,
+          grid: { drawOnChartArea: false },
+          title: { display: true, text: 'NOK / mnd' },
+          ticks: {
+            callback: (value) =>
+              typeof value === 'number' ? value.toLocaleString('nb-NO', { maximumFractionDigits: 0 }) : String(value),
+          },
+        },
+      },
+    }),
+    [],
+  )
+
+  if (!chart) {
+    return (
+      <VStack gap="space-4" align="center" padding="space-32" style={{ height: '300px', justifyContent: 'center' }}>
+        <BodyShort weight="semibold">Ingen datapunkter</BodyShort>
+        <BodyShort size="small">Ingen mottakere funnet i valgt tidsrom. Prøv å velge en lengre periode.</BodyShort>
+      </VStack>
+    )
+  }
+
+  return (
+    <div
+      style={{ height: '320px', position: 'relative' }}
+      role="img"
+      aria-label="Combo-graf: Nye mottakere og opphør per periode, samt snitt månedlig brutto for nye mottakere"
+    >
+      <Chart type="bar" data={chart} options={options} />
+    </div>
+  )
+}

--- a/app/analyse/components/NettoEndringChart.tsx
+++ b/app/analyse/components/NettoEndringChart.tsx
@@ -1,0 +1,156 @@
+import { BodyShort, VStack } from '@navikt/ds-react'
+import type { ChartData, ChartOptions } from 'chart.js'
+import {
+  BarController,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { useMemo } from 'react'
+import { Chart } from 'react-chartjs-2'
+import type { AlderspensjonMottakereDatapunkt } from '../types'
+import { formaterPeriodeLabel, formaterTall } from '../utils/formattering'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  LineController,
+  BarController,
+  Title,
+  Tooltip,
+  Legend,
+)
+
+interface Props {
+  data: AlderspensjonMottakereDatapunkt[]
+}
+
+const POSITIV_BG = 'rgba(6, 137, 84, 0.55)'
+const POSITIV_BORDER = 'rgba(6, 137, 84, 1)'
+const NEGATIV_BG = 'rgba(196, 48, 43, 0.55)'
+const NEGATIV_BORDER = 'rgba(196, 48, 43, 1)'
+const AKKUMULERT_COLOR = 'rgba(99, 102, 241, 1)'
+const AKKUMULERT_BG = 'rgba(99, 102, 241, 0.15)'
+
+/**
+ * Visualiserer bestandsutvikling for alderspensjon-mottakere:
+ * - Søyler per periode for netto endring (antallNye − antallOpphor),
+ *   farget grønn ved vekst og rød ved nedgang.
+ * - Linje for akkumulert netto over tidsrommet (sekundær y-akse).
+ */
+export default function NettoEndringChart({ data }: Props) {
+  const chart = useMemo(() => {
+    if (data.length === 0) return null
+
+    const sorted = [...data].sort((a, b) => a.periodeFra.localeCompare(b.periodeFra))
+    const labels = sorted.map((d) => d.periodeFra)
+    const netto = sorted.map((d) => d.antallNye - d.antallOpphor)
+
+    let lopende = 0
+    const akkumulert = netto.map((n) => {
+      lopende += n
+      return lopende
+    })
+
+    const bgColors = netto.map((n) => (n >= 0 ? POSITIV_BG : NEGATIV_BG))
+    const borderColors = netto.map((n) => (n >= 0 ? POSITIV_BORDER : NEGATIV_BORDER))
+
+    const datasets: ChartData<'bar' | 'line'>['datasets'] = [
+      {
+        type: 'bar' as const,
+        label: 'Netto pr. periode',
+        data: netto,
+        backgroundColor: bgColors,
+        borderColor: borderColors,
+        borderWidth: 1,
+        yAxisID: 'y',
+      },
+      {
+        type: 'line' as const,
+        label: 'Akkumulert netto',
+        data: akkumulert,
+        borderColor: AKKUMULERT_COLOR,
+        backgroundColor: AKKUMULERT_BG,
+        borderWidth: 1.8,
+        tension: 0.3,
+        pointRadius: sorted.length > 30 ? 0 : 2,
+        yAxisID: 'y1',
+      },
+    ]
+
+    return { labels, datasets } as ChartData<'bar' | 'line'>
+  }, [data])
+
+  const options: ChartOptions<'bar' | 'line'> = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index' as const, intersect: false },
+      plugins: {
+        legend: { display: true, position: 'top' as const },
+        tooltip: {
+          callbacks: {
+            title: (items) => formaterPeriodeLabel(items[0]?.label ?? ''),
+            label: (item) => {
+              const v = item.parsed.y
+              if (v == null) return `${item.dataset.label}: –`
+              const fortegn = v > 0 ? '+' : ''
+              return `${item.dataset.label}: ${fortegn}${formaterTall(v)}`
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: {
+            callback: function (value) {
+              return formaterPeriodeLabel(this.getLabelForValue(value as number))
+            },
+            maxTicksLimit: 12,
+          },
+        },
+        y: {
+          type: 'linear' as const,
+          position: 'left' as const,
+          title: { display: true, text: 'Netto pr. periode' },
+        },
+        y1: {
+          type: 'linear' as const,
+          position: 'right' as const,
+          grid: { drawOnChartArea: false },
+          title: { display: true, text: 'Akkumulert netto' },
+        },
+      },
+    }),
+    [],
+  )
+
+  if (!chart) {
+    return (
+      <VStack gap="space-4" align="center" padding="space-32" style={{ height: '300px', justifyContent: 'center' }}>
+        <BodyShort weight="semibold">Ingen datapunkter</BodyShort>
+        <BodyShort size="small">Ingen mottakere funnet i valgt tidsrom. Prøv å velge en lengre periode.</BodyShort>
+      </VStack>
+    )
+  }
+
+  return (
+    <div
+      style={{ height: '300px', position: 'relative' }}
+      role="img"
+      aria-label="Graf: Netto endring per periode (grønn ved vekst, rød ved nedgang) og akkumulert netto over tidsrommet"
+    >
+      <Chart type="bar" data={chart} options={options} />
+    </div>
+  )
+}

--- a/app/analyse/mocks.ts
+++ b/app/analyse/mocks.ts
@@ -1072,3 +1072,44 @@ export function mockBehandlingKravAlderData(): import('./types').BehandlingKravA
     ],
   }
 }
+
+export function mockAlderspensjonMottakereData(): import('./types').AlderspensjonMottakereResponse {
+  const months = [
+    '2024-01-01T00:00:00',
+    '2024-02-01T00:00:00',
+    '2024-03-01T00:00:00',
+    '2024-04-01T00:00:00',
+    '2024-05-01T00:00:00',
+    '2024-06-01T00:00:00',
+    '2024-07-01T00:00:00',
+    '2024-08-01T00:00:00',
+    '2024-09-01T00:00:00',
+    '2024-10-01T00:00:00',
+    '2024-11-01T00:00:00',
+    '2024-12-01T00:00:00',
+  ]
+  const nye = [5234, 4987, 5410, 5123, 4890, 4720, 4250, 4180, 5320, 5510, 5180, 4960]
+  const opphor = [3812, 3654, 3970, 3810, 3720, 3680, 3550, 3490, 3820, 3910, 3870, 3760]
+  const brutto = [
+    287654.12,
+    null,
+    291230.55,
+    289450.0,
+    293120.4,
+    295800.1,
+    298400.0,
+    297500.0,
+    301250.5,
+    303400.0,
+    305120.0,
+    307800.0,
+  ]
+  return {
+    datapunkter: months.map((periodeFra, i) => ({
+      periodeFra,
+      antallNye: nye[i],
+      antallOpphor: opphor[i],
+      gjennomsnittBruttoPerAarNyeMottakere: brutto[i],
+    })),
+  }
+}

--- a/app/analyse/mottakere-alder.tsx
+++ b/app/analyse/mottakere-alder.tsx
@@ -1,0 +1,192 @@
+import { BodyShort, Heading, HStack, Skeleton, Table, VStack } from '@navikt/ds-react'
+import React, { useCallback } from 'react'
+import { AnalyseErrorAlert } from '~/analyse/utils/AnalyseErrorAlert'
+import { apiGet } from '~/services/api.server'
+import type { Route } from './+types/mottakere-alder'
+import LastNedTabData from './components/LastNedTabData'
+import type { AlderspensjonMottakereDatapunkt, AlderspensjonMottakereResponse } from './types'
+import { formaterPeriodeLabel, formaterTall } from './utils/formattering'
+import { parseAlderspensjonParams } from './utils/parseAlderspensjonParams'
+import { useSortableTable } from './utils/useSortableTable'
+
+const MottakereAlderChart = React.lazy(() => import('./components/MottakereAlderChart'))
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: 'Alderspensjon — mottakere | Verdande' }]
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const { paramsAgg } = parseAlderspensjonParams(request)
+  return await apiGet<AlderspensjonMottakereResponse>(`/api/sak/analyse/alderspensjon-mottakere?${paramsAgg}`, request)
+}
+
+type Rad = AlderspensjonMottakereDatapunkt & {
+  nettoEndring: number
+  snittBruttoPerMnd: number | null
+}
+
+function berikRader(datapunkter: AlderspensjonMottakereDatapunkt[]): Rad[] {
+  return datapunkter.map((d) => ({
+    ...d,
+    nettoEndring: d.antallNye - d.antallOpphor,
+    snittBruttoPerMnd:
+      d.gjennomsnittBruttoPerAarNyeMottakere == null ? null : d.gjennomsnittBruttoPerAarNyeMottakere / 12,
+  }))
+}
+
+function formaterNok(value: number | null | undefined): string {
+  if (value == null) return '–'
+  return `${value.toLocaleString('nb-NO', { maximumFractionDigits: 0 })} kr`
+}
+
+export default function MottakereAlderTab({ loaderData }: Route.ComponentProps) {
+  const datapunkter = loaderData.datapunkter
+  const rader = React.useMemo(() => berikRader(datapunkter), [datapunkter])
+
+  const totalNye = rader.reduce((s, r) => s + r.antallNye, 0)
+  const totalOpphor = rader.reduce((s, r) => s + r.antallOpphor, 0)
+  const nettoEndring = totalNye - totalOpphor
+
+  // Vektet snitt brutto over perioder som har verdi (vekt = antallNye).
+  // Vi sporer også hvor mange nye mottakere som ikke inngår i snittet (perioder
+  // der gjennomsnittBruttoPerAarNyeMottakere er null) for tydelig KPI-kommunikasjon.
+  const { sumBrutto, antallMedBrutto, antallUtenBrutto } = rader.reduce(
+    (acc, r) => {
+      if (r.gjennomsnittBruttoPerAarNyeMottakere != null) {
+        acc.sumBrutto += r.gjennomsnittBruttoPerAarNyeMottakere * r.antallNye
+        acc.antallMedBrutto += r.antallNye
+      } else {
+        acc.antallUtenBrutto += r.antallNye
+      }
+      return acc
+    },
+    { sumBrutto: 0, antallMedBrutto: 0, antallUtenBrutto: 0 },
+  )
+  const vektetSnittBruttoPerAar = antallMedBrutto > 0 ? sumBrutto / antallMedBrutto : null
+  const vektetSnittBruttoPerMnd = vektetSnittBruttoPerAar == null ? null : vektetSnittBruttoPerAar / 12
+  const dekningstekst =
+    antallMedBrutto > 0 && antallUtenBrutto > 0
+      ? `${antallMedBrutto.toLocaleString('nb-NO')} av ${(antallMedBrutto + antallUtenBrutto).toLocaleString('nb-NO')} nye inngår`
+      : null
+
+  const getValue = useCallback((item: Rad, key: string): number | string | null => {
+    if (key === 'periodeFra') return item.periodeFra
+    if (
+      key === 'antallNye' ||
+      key === 'antallOpphor' ||
+      key === 'nettoEndring' ||
+      key === 'gjennomsnittBruttoPerAarNyeMottakere' ||
+      key === 'snittBruttoPerMnd'
+    ) {
+      return (item[key] as number | null) ?? null
+    }
+    return null
+  }, [])
+
+  const { sort, handleSort, sorted } = useSortableTable(rader, 'periodeFra', 'ascending', getValue)
+
+  return (
+    <VStack gap="space-16">
+      <BodyShort size="small" textColor="subtle">
+        Tidsserie over nye mottakere (vedtakstype FORGANG) og opphør (vedtakstype OPPHOR) for sakstype ALDER, samt snitt
+        utbetaling for nye mottakere i perioden. Aggregeres på virkningsdato (DATO_VIRK_FOM). Data fra pensjon-pen
+        (T_VEDTAK + T_BEREGNING).
+      </BodyShort>
+
+      <HStack gap="space-32" wrap>
+        <VStack gap="space-4" align="center" style={{ minWidth: '140px' }}>
+          <Heading level="3" size="large">
+            {totalNye.toLocaleString('nb-NO')}
+          </Heading>
+          <BodyShort size="small">Totalt nye mottakere</BodyShort>
+        </VStack>
+        <VStack gap="space-4" align="center" style={{ minWidth: '140px' }}>
+          <Heading level="3" size="large">
+            {totalOpphor.toLocaleString('nb-NO')}
+          </Heading>
+          <BodyShort size="small">Totalt opphør</BodyShort>
+        </VStack>
+        <VStack gap="space-4" align="center" style={{ minWidth: '140px' }}>
+          <Heading level="3" size="large">
+            {nettoEndring >= 0 ? '+' : ''}
+            {nettoEndring.toLocaleString('nb-NO')}
+          </Heading>
+          <BodyShort size="small">Netto endring</BodyShort>
+        </VStack>
+        <VStack gap="space-4" align="center" style={{ minWidth: '180px' }}>
+          <Heading level="3" size="large">
+            {formaterNok(vektetSnittBruttoPerMnd)}
+          </Heading>
+          <BodyShort size="small">Snitt brutto/mnd, nye (vektet)</BodyShort>
+          {dekningstekst && (
+            <BodyShort size="small" textColor="subtle">
+              {dekningstekst}
+            </BodyShort>
+          )}
+        </VStack>
+      </HStack>
+
+      <VStack gap="space-8">
+        <Heading level="3" size="small">
+          Tilvekst, avgang og snitt utbetaling
+        </Heading>
+        <BodyShort size="small" textColor="subtle">
+          Linjer viser nye mottakere og opphør per periode. Søyler viser snitt månedlig brutto for nye mottakere (NOK).
+        </BodyShort>
+        <React.Suspense fallback={<Skeleton variant="rounded" width="100%" height={320} />}>
+          <MottakereAlderChart data={datapunkter} />
+        </React.Suspense>
+      </VStack>
+
+      {rader.length > 0 && (
+        <Table size="small" zebraStripes sort={sort} onSortChange={handleSort}>
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader sortable sortKey="periodeFra">
+                Periode
+              </Table.ColumnHeader>
+              <Table.ColumnHeader sortable sortKey="antallNye" align="right">
+                Nye
+              </Table.ColumnHeader>
+              <Table.ColumnHeader sortable sortKey="antallOpphor" align="right">
+                Opphør
+              </Table.ColumnHeader>
+              <Table.ColumnHeader sortable sortKey="nettoEndring" align="right">
+                Netto
+              </Table.ColumnHeader>
+              <Table.ColumnHeader sortable sortKey="gjennomsnittBruttoPerAarNyeMottakere" align="right">
+                Snitt brutto/år (nye)
+              </Table.ColumnHeader>
+              <Table.ColumnHeader sortable sortKey="snittBruttoPerMnd" align="right">
+                Snitt brutto/mnd (nye)
+              </Table.ColumnHeader>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {sorted.map((r) => (
+              <Table.Row key={r.periodeFra}>
+                <Table.DataCell>{formaterPeriodeLabel(r.periodeFra)}</Table.DataCell>
+                <Table.DataCell align="right">{formaterTall(r.antallNye)}</Table.DataCell>
+                <Table.DataCell align="right">{formaterTall(r.antallOpphor)}</Table.DataCell>
+                <Table.DataCell align="right">
+                  {r.nettoEndring >= 0 ? '+' : ''}
+                  {r.nettoEndring.toLocaleString('nb-NO')}
+                </Table.DataCell>
+                <Table.DataCell align="right">{formaterNok(r.gjennomsnittBruttoPerAarNyeMottakere)}</Table.DataCell>
+                <Table.DataCell align="right">{formaterNok(r.snittBruttoPerMnd)}</Table.DataCell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      <HStack justify="end">
+        <LastNedTabData data={rader} filnavn="alderspensjon-mottakere" />
+      </HStack>
+    </VStack>
+  )
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <AnalyseErrorAlert error={error} label="alderspensjon-mottakere" />
+}

--- a/app/analyse/mottakere-alder.tsx
+++ b/app/analyse/mottakere-alder.tsx
@@ -10,6 +10,7 @@ import { parseAlderspensjonParams } from './utils/parseAlderspensjonParams'
 import { useSortableTable } from './utils/useSortableTable'
 
 const MottakereAlderChart = React.lazy(() => import('./components/MottakereAlderChart'))
+const NettoEndringChart = React.lazy(() => import('./components/NettoEndringChart'))
 
 export function meta(): Route.MetaDescriptors {
   return [{ title: 'Alderspensjon — mottakere | Verdande' }]
@@ -135,6 +136,19 @@ export default function MottakereAlderTab({ loaderData }: Route.ComponentProps) 
         </BodyShort>
         <React.Suspense fallback={<Skeleton variant="rounded" width="100%" height={320} />}>
           <MottakereAlderChart data={datapunkter} />
+        </React.Suspense>
+      </VStack>
+
+      <VStack gap="space-8">
+        <Heading level="3" size="small">
+          Bestandsutvikling — netto endring
+        </Heading>
+        <BodyShort size="small" textColor="subtle">
+          Søyler viser netto endring per periode (grønn = vekst, rød = nedgang). Linjen viser akkumulert netto over
+          valgt tidsrom og indikerer om bestanden samlet sett øker eller går ned.
+        </BodyShort>
+        <React.Suspense fallback={<Skeleton variant="rounded" width="100%" height={300} />}>
+          <NettoEndringChart data={datapunkter} />
         </React.Suspense>
       </VStack>
 

--- a/app/analyse/route.stories.tsx
+++ b/app/analyse/route.stories.tsx
@@ -7,6 +7,7 @@ import { createRoutesStub } from 'react-router'
 import AktiviteterTab from './aktiviteter'
 import AktiviteterLayout from './aktiviteter-layout'
 import AktivitetsvarighetTab from './aktivitetsvarighet'
+import AlderspensjonLayout from './alderspensjon-layout'
 import AutomatiseringTab from './automatisering'
 import AutomatiseringLayout from './automatisering-layout'
 import DimensjonerLayout from './dimensjoner-layout'
@@ -22,6 +23,7 @@ import ManuelleTab from './manuelle'
 import {
   mockAktivitetData,
   mockAktivitetsvarighetData,
+  mockAlderspensjonMottakereData,
   mockAutomatiseringData,
   mockBehandlingKravAlderData,
   mockBehandlingstidPerTypeData,
@@ -49,6 +51,7 @@ import {
   mockVarighetData,
   mockVedtakstypeData,
 } from './mocks'
+import MottakereAlderTab from './mottakere-alder'
 import Nokkeltall from './nokkeltall'
 import PlanlagtTab from './planlagt'
 import PrioritetTab from './prioritet'
@@ -307,4 +310,31 @@ export const SakBehandlingstidStory: Story = {
 export const BehandlingKravAlderStory: Story = {
   name: 'Behandling per alder',
   render: () => renderAnalyseTab(SakBehandlingKravAlderTab, mockBehandlingKravAlderData(), 'sak-behandling-krav-alder'),
+}
+
+// --- Alderspensjon ---
+
+function renderAlderspensjonTab() {
+  const Stub = createRoutesStub([
+    {
+      path: '/analyse/alderspensjon',
+      // biome-ignore lint/suspicious/noExplicitAny: createRoutesStub type mismatch with react-router typed routes
+      Component: AlderspensjonLayout as any,
+      loader: () => ({ fom: '2024-01-01', tom: '2026-01-01', aggregering: 'MAANED' }),
+      children: [
+        {
+          path: 'mottakere',
+          // biome-ignore lint/suspicious/noExplicitAny: createRoutesStub type mismatch with react-router typed routes
+          Component: MottakereAlderTab as any,
+          loader: () => mockAlderspensjonMottakereData(),
+        },
+      ],
+    },
+  ])
+  return <Stub initialEntries={['/analyse/alderspensjon/mottakere?fom=2024-01-01&tom=2026-01-01&aggregering=MAANED']} />
+}
+
+export const AlderspensjonMottakereStory: Story = {
+  name: 'Alderspensjon — mottakere',
+  render: renderAlderspensjonTab,
 }

--- a/app/analyse/types.ts
+++ b/app/analyse/types.ts
@@ -554,3 +554,17 @@ export type BrevTidsserieDatapunkt = {
   periodeFra: string
   antall: number
 }
+
+// --- Alderspensjon mottakere (tilvekst og avgang) ---
+
+export type AlderspensjonMottakereResponse = {
+  datapunkter: AlderspensjonMottakereDatapunkt[]
+}
+
+export type AlderspensjonMottakereDatapunkt = {
+  periodeFra: string
+  antallNye: number
+  antallOpphor: number
+  /** Årlig brutto, snitt over nye mottakere i perioden. Null hvis ingen vinnende beregning. */
+  gjennomsnittBruttoPerAarNyeMottakere: number | null
+}

--- a/app/analyse/utils/parseAlderspensjonParams.test.ts
+++ b/app/analyse/utils/parseAlderspensjonParams.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { parseAlderspensjonParams } from './parseAlderspensjonParams'
+
+const req = (qs: string) => new Request(`http://x/?${qs}`)
+
+describe('parseAlderspensjonParams', () => {
+  it('beholder rekkefølge når fom < tom', () => {
+    const { fom, tom } = parseAlderspensjonParams(req('fom=2024-01-01&tom=2024-06-01'))
+    expect(fom).toBe('2024-01-01')
+    expect(tom).toBe('2024-06-01')
+  })
+
+  it('bytter fom/tom når fom > tom (rene datoer)', () => {
+    const { fom, tom } = parseAlderspensjonParams(req('fom=2024-06-01&tom=2024-01-01'))
+    expect(fom).toBe('2024-01-01')
+    expect(tom).toBe('2024-06-01')
+  })
+
+  it('bytter ikke når fom (med tid) er senere på samme dag som tom (dato)', () => {
+    // Tidligere bug: leksikografisk swap byttet disse selv om fom < tom kronologisk
+    const { fom, tom } = parseAlderspensjonParams(req('fom=2024-01-10T12:00:00.000&tom=2024-01-10'))
+    // Etter normalisering: tom=2024-01-10T23:59:59.999 > fom=2024-01-10T12:00:00.000 → ingen swap
+    expect(fom).toBe('2024-01-10T12:00:00.000')
+    expect(tom).toBe('2024-01-10')
+  })
+
+  it('faller tilbake til MAANED ved ugyldig aggregering', () => {
+    const { aggregering } = parseAlderspensjonParams(req('aggregering=MINUTT'))
+    expect(aggregering).toBe('MAANED')
+  })
+
+  it('aksepterer gyldig aggregering', () => {
+    const { aggregering } = parseAlderspensjonParams(req('aggregering=KVARTAL'))
+    expect(aggregering).toBe('KVARTAL')
+  })
+
+  it('bygger paramsAgg med utvidet timestamp for rene datoer', () => {
+    const { paramsAgg } = parseAlderspensjonParams(req('fom=2024-01-01&tom=2024-06-01'))
+    expect(paramsAgg.get('fom')).toBe('2024-01-01T00:00:00.000')
+    expect(paramsAgg.get('tom')).toBe('2024-06-01T23:59:59.999')
+    expect(paramsAgg.get('aggregering')).toBe('MAANED')
+  })
+})

--- a/app/analyse/utils/parseAlderspensjonParams.ts
+++ b/app/analyse/utils/parseAlderspensjonParams.ts
@@ -27,7 +27,10 @@ export function parseAlderspensjonParams(request: Request): AlderspensjonParams 
 
   let fom = url.searchParams.get('fom') || toIsoDate(sub(now, { months: 24 }))
   let tom = url.searchParams.get('tom') || toIsoDate(now)
-  if (fom > tom) {
+  // Sammenlign på dato-prefiks (YYYY-MM-DD) for å unngå feil swap når formatene er blandet
+  // (f.eks. fom='2024-01-10T12:00:00' og tom='2024-01-10'). Innen samme dag gir swap
+  // uansett ikke meningsfull endring, så det er trygt å ikke bytte da.
+  if (fom.slice(0, 10) > tom.slice(0, 10)) {
     ;[fom, tom] = [tom, fom]
   }
 

--- a/app/analyse/utils/parseAlderspensjonParams.ts
+++ b/app/analyse/utils/parseAlderspensjonParams.ts
@@ -1,0 +1,43 @@
+import { sub } from 'date-fns'
+import { toIsoDate } from '~/common/date'
+import type { Aggregeringsniva } from '../types'
+
+export type AlderspensjonParams = {
+  fom: string
+  tom: string
+  aggregering: Aggregeringsniva
+  /** Query string: `fom=...&tom=...&aggregering=...` */
+  paramsAgg: URLSearchParams
+}
+
+const GYLDIGE_AGGREGERINGER: Aggregeringsniva[] = ['DAG', 'UKE', 'MAANED', 'KVARTAL', 'AAR']
+
+/**
+ * Parser for parametre til /api/sak/analyse/alderspensjon-mottakere.
+ *
+ * Endepunktet tar kun fom, tom og aggregering. Default er siste 24 måneder med
+ * MAANED-aggregering, som passer typisk månedstidsserie-bruk fra Utbetaling.
+ *
+ * Ugyldig aggregering (eller verdier endepunktet ikke støtter, f.eks. MINUTT/TIME)
+ * faller tilbake til MAANED. Hvis fom > tom, byttes de om for å unngå tom respons.
+ */
+export function parseAlderspensjonParams(request: Request): AlderspensjonParams {
+  const url = new URL(request.url)
+  const now = new Date()
+
+  let fom = url.searchParams.get('fom') || toIsoDate(sub(now, { months: 24 }))
+  let tom = url.searchParams.get('tom') || toIsoDate(now)
+  if (fom > tom) {
+    ;[fom, tom] = [tom, fom]
+  }
+
+  const rawAgg = url.searchParams.get('aggregering') as Aggregeringsniva | null
+  const aggregering: Aggregeringsniva = rawAgg && GYLDIGE_AGGREGERINGER.includes(rawAgg) ? rawAgg : 'MAANED'
+
+  const fomTimestamp = fom.includes('T') ? fom : `${fom}T00:00:00.000`
+  const tomTimestamp = tom.includes('T') ? tom : `${tom}T23:59:59.999`
+
+  const paramsAgg = new URLSearchParams({ fom: fomTimestamp, tom: tomTimestamp, aggregering })
+
+  return { fom, tom, aggregering, paramsAgg }
+}

--- a/app/components/venstre-meny/VenstreMeny.tsx
+++ b/app/components/venstre-meny/VenstreMeny.tsx
@@ -99,6 +99,8 @@ const sakKravAnalyseMeny = [
   ['SE_BEHANDLINGER', '/analyse/sak-krav/behandlingstid', 'Behandlingstid'],
 ]
 
+const alderspensjonAnalyseMeny = [['SE_BEHANDLINGER', '/analyse/alderspensjon/mottakere', 'Mottakere']]
+
 export function harTilgang(me: MeResponse | undefined, operasjon: string) {
   if (!me) {
     return false
@@ -117,10 +119,13 @@ export default function VenstreMeny(props: Props) {
   const me = props.me
   const location = useLocation()
   const analyseSearch =
-    location.pathname.startsWith('/analyse') && !location.pathname.startsWith('/analyse/sak-krav')
+    location.pathname.startsWith('/analyse') &&
+    !location.pathname.startsWith('/analyse/sak-krav') &&
+    !location.pathname.startsWith('/analyse/alderspensjon')
       ? location.search
       : ''
   const sakKravSearch = location.pathname.startsWith('/analyse/sak-krav') ? location.search : ''
+  const alderspensjonSearch = location.pathname.startsWith('/analyse/alderspensjon') ? location.search : ''
   let currentIndex = 0
 
   function nextIndex() {
@@ -275,6 +280,15 @@ export default function VenstreMeny(props: Props) {
             <FileSearchIcon title="Sak- og kravanalyse" fontSize="1.5rem" />,
             false,
             sakKravSearch,
+          )}
+
+          {byggMeny(
+            'Alderspensjon-analyse',
+            alderspensjonAnalyseMeny,
+            nextIndex,
+            <SackPensionIcon title="Alderspensjon-analyse" fontSize="1.5rem" />,
+            false,
+            alderspensjonSearch,
           )}
 
           {byggMeny(

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -83,6 +83,11 @@ export default [
     ]),
     route('analyse/eksport', 'analyse/eksport.tsx'),
 
+    route('analyse/alderspensjon', 'analyse/alderspensjon-layout.tsx', [
+      index('analyse/alderspensjon-index.tsx'),
+      route('mottakere', 'analyse/mottakere-alder.tsx'),
+    ]),
+
     route('aldersovergang', 'aldersovergang/aldersovergang._index.tsx'),
 
     route('aldersovergang/opprett', 'aldersovergang/aldersovergang.opprett.tsx'),


### PR DESCRIPTION
## Hva
Eksponerer det nye PEN-endepunktet `GET /api/sak/analyse/alderspensjon-mottakere` (m\u00e5nedstidsserie over tilvekst, avgang og snitt utbetaling for alderspensjon-mottakere) som en ny seksjon i Verdande.

## Hvor
Ny seksjon under `/analyse/alderspensjon` med fane `mottakere`. Lagt til som egen menygruppe `Alderspensjon-analyse` i venstremenyen.

## UI
- S\u00f8kekriterier: fra/til-dato med hurtigvalg (12 mnd, 24 mnd, 5 \u00e5r, hittil i \u00e5r, hele historikken), aggregeringsniv\u00e5 (DAG/UKE/MAANED/KVARTAL/AAR).
- 4 n\u00f8kkeltallskort: totalt nye, totalt opph\u00f8r, netto endring, vektet snitt brutto/mnd for nye mottakere (med dekningstekst hvis noen perioder mangler bruttoverdi).
- Combo-graf: linjer for nye/opph\u00f8r per periode + s\u00f8yler for snitt m\u00e5nedlig brutto p\u00e5 sekund\u00e6rakse.
- Sortbar tabell med periode, nye, opph\u00f8r, netto, snitt brutto/\u00e5r og /mnd.
- CSV/JSON-eksport via felles `LastNedTabData`.
- ErrorBoundary med felles `AnalyseErrorAlert` (timeout-vennlig melding).

## M\u00f8nstre fulgt (AGENTS.md)
- `apiGet` direkte i loader (ingen wrapper, ingen direkte `fetch`).
- React Router typegen (`Route.LoaderArgs` osv.).
- Aksel-komponenter (Darkside-kompatibelt).
- Gjenbruk av `formaterPeriodeLabel`, `formaterTall`, `useSortableTable`, `SectionTabLayout`, `normalizePeriodToDate`.
- `parseAlderspensjonParams` whitelister gyldige aggregeringsniv\u00e5er og bytter fom/tom hvis snudd.

## Tester
- Storybook-story `AlderspensjonMottakereStory` med mockdata.
- `npm run check`, `npm run typecheck`, `npm test` (188), `npm run test:stories` (208), `npm run build` \u2014 alle gr\u00f8nne lokalt.