### PR TITLE
Behandlingssøk: generisk søk- og analyseverktøy for behandlinger

### DIFF
--- a/app/behandling-sok/api.antall.ts
+++ b/app/behandling-sok/api.antall.ts
@@ -1,0 +1,34 @@
+/**
+ * Resource route for «antall over tid»-søk (POST).
+ * Brukes når sensitive kriterier holdes i sessionStorage og loaderen ikke kan kjøre søket
+ * server-side på første render.
+ */
+import { data } from 'react-router'
+import { apiPost } from '~/services/api.server'
+import type { Bucket } from './components/AntallOverTidChart'
+import type { AntallOverTidRequest } from './lib/request-builder'
+
+export type AntallOverTidResponse = { totalAntall: number; buckets: Bucket[] }
+
+export async function action({ request }: { request: Request }) {
+  if (request.method !== 'POST') {
+    return data({ error: 'Method not allowed' }, { status: 405 })
+  }
+  let body: AntallOverTidRequest
+  try {
+    body = (await request.json()) as AntallOverTidRequest
+  } catch {
+    return data({ error: 'Ugyldig JSON-body' }, { status: 400 })
+  }
+  if (!body.behandlingType) {
+    return data({ error: 'behandlingType er påkrevd' }, { status: 400 })
+  }
+  try {
+    const res = await apiPost<AntallOverTidResponse>('/api/behandling/sok/antall-over-tid', body, request)
+    return data(res)
+  } catch (e) {
+    const status = (e as { data?: { status?: number } })?.data?.status ?? 500
+    const msg = (e as { data?: { detail?: string } })?.data?.detail ?? 'Søket feilet'
+    return data({ error: msg }, { status })
+  }
+}

--- a/app/behandling-sok/api.metadata.ts
+++ b/app/behandling-sok/api.metadata.ts
@@ -1,0 +1,24 @@
+/**
+ * Resource route for å hente metadata for en behandlingstype on demand.
+ * Kalles fra hovedsiden via useFetcher når brukeren bytter behandlingstype i draft,
+ * slik at editorene viser dropdowns for valgt type uten at brukeren må kjøre søk først.
+ */
+import { data } from 'react-router'
+import { hentBehandlingMetadata } from './metadata-cache.server'
+
+export async function loader({ request }: { request: Request }) {
+  const url = new URL(request.url)
+  const behandlingType = url.searchParams.get('type')
+  if (!behandlingType) {
+    return data({ error: 'type-parameter mangler' }, { status: 400 })
+  }
+  try {
+    const metadata = await hentBehandlingMetadata(behandlingType, request)
+    return data(metadata)
+  } catch (e) {
+    const status = (e as { data?: { status?: number } })?.data?.status ?? 500
+    if (status === 401 || status === 403) throw e
+    const msg = (e as { data?: { detail?: string } })?.data?.detail ?? 'Kunne ikke hente metadata'
+    return data({ error: msg }, { status })
+  }
+}

--- a/app/behandling-sok/api.treff.ts
+++ b/app/behandling-sok/api.treff.ts
@@ -1,0 +1,36 @@
+/**
+ * Resource route for cursor-paginering av treff (POST).
+ * Kalles via useFetcher fra hovedsiden når brukeren trykker «Last mer».
+ */
+import { data } from 'react-router'
+import { apiPost } from '~/services/api.server'
+import type { Treff } from './components/TreffTabell'
+import type { TreffRequest } from './lib/request-builder'
+
+export type TreffResponse = {
+  treff: Treff[]
+  nesteCursor: { opprettet: string; behandlingId: number } | null
+}
+
+export async function action({ request }: { request: Request }) {
+  if (request.method !== 'POST') {
+    return data({ error: 'Method not allowed' }, { status: 405 })
+  }
+  let body: TreffRequest
+  try {
+    body = (await request.json()) as TreffRequest
+  } catch {
+    return data({ error: 'Ugyldig JSON-body' }, { status: 400 })
+  }
+  if (!body.behandlingType) {
+    return data({ error: 'behandlingType er påkrevd' }, { status: 400 })
+  }
+  try {
+    const res = await apiPost<TreffResponse>('/api/behandling/sok/treff', body, request)
+    return data(res)
+  } catch (e) {
+    const status = (e as { data?: { status?: number } })?.data?.status ?? 500
+    const msg = (e as { data?: { detail?: string } })?.data?.detail ?? 'Søket feilet'
+    return data({ error: msg }, { status })
+  }
+}

--- a/app/behandling-sok/behandling-sok.stories.tsx
+++ b/app/behandling-sok/behandling-sok.stories.tsx
@@ -17,6 +17,7 @@ const metadata: BehandlingMetadata = {
   kravGjelderKoder: ['AP', 'UT'],
   sakstyper: ['ALDER', 'UFORE'],
   eierenheter: ['4849', '4862'],
+  kravhodeBehandlingTyper: ['FORSTEG_BH', 'REVURD'],
 }
 
 const meta: Meta<typeof BehandlingSokPage> = {

--- a/app/behandling-sok/behandling-sok.stories.tsx
+++ b/app/behandling-sok/behandling-sok.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { renderWithLoader } from '../../.storybook/mocks/router'
+import BehandlingSokPage from './behandling-sok'
+import type { BehandlingMetadata } from './metadata-cache.server'
+
+const metadata: BehandlingMetadata = {
+  schemaVersion: '1',
+  metadataVersion: 'm-1',
+  generatedAt: '2025-04-01T00:00:00Z',
+  behandlingType: 'AlderspensjonForstegangsbehandling',
+  supportedAktivitetTyper: ['SjekkUtland', 'SjekkSamboer', 'IverksettVedtak'],
+  observedAktivitetTyper: ['SjekkUtland', 'SjekkSamboer', 'IverksettVedtak'],
+  behandlingStatuser: ['REGISTRERT', 'IVERKSATT', 'STOPPET'],
+  ansvarligeTeam: ['TEAM_ALDER', 'TEAM_UFORE'],
+  kravStatuser: ['INNSENDT', 'UNDER_BEHANDLING', 'INNVILGET'],
+  kontrollpunktTyper: [{ kode: 'KP_BEHANDLE_UTLAND', dekodeTekst: 'Behandle utland' }],
+  kravGjelderKoder: ['AP', 'UT'],
+  sakstyper: ['ALDER', 'UFORE'],
+  eierenheter: ['4849', '4862'],
+}
+
+const meta: Meta<typeof BehandlingSokPage> = {
+  title: 'Pages/BehandlingSok',
+  component: BehandlingSokPage,
+}
+export default meta
+
+type Story = StoryObj<typeof BehandlingSokPage>
+
+export const Default: Story = {
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling', 'UforetrygdBehandling'],
+      metadata: null,
+      committed: {
+        behandlingType: null,
+        ikkeSensitiveKriterier: [],
+        visning: 'treff',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      ukjenteKriterier: [],
+      harSensitiveISok: false,
+      initialResultat: null,
+      feilmelding: null,
+    }),
+}
+
+export const MedTreff: Story = {
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling'],
+      metadata,
+      committed: {
+        behandlingType: 'AlderspensjonForstegangsbehandling',
+        ikkeSensitiveKriterier: [
+          { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-03-31' },
+          { type: 'HAR_STATUS', statuser: ['STOPPET'] },
+        ],
+        visning: 'treff',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      ukjenteKriterier: [],
+      harSensitiveISok: false,
+      initialResultat: {
+        kind: 'treff',
+        data: {
+          treff: [
+            {
+              behandlingId: 12345,
+              behandlingType: 'AlderspensjonForstegangsbehandling',
+              status: 'STOPPET',
+              ansvarligTeam: 'TEAM_ALDER',
+              opprettet: '2025-02-15T10:00:00',
+              prioritet: 50,
+            },
+            {
+              behandlingId: 12346,
+              behandlingType: 'AlderspensjonForstegangsbehandling',
+              status: 'STOPPET',
+              ansvarligTeam: 'TEAM_ALDER',
+              opprettet: '2025-02-16T11:00:00',
+              prioritet: 40,
+            },
+          ],
+          nesteCursor: { opprettet: '2025-02-16T11:00:00', behandlingId: 12346 },
+        },
+      },
+      feilmelding: null,
+    }),
+}
+
+export const AntallOverTid: Story = {
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling'],
+      metadata,
+      committed: {
+        behandlingType: 'AlderspensjonForstegangsbehandling',
+        ikkeSensitiveKriterier: [{ type: 'OPPRETTET_I_PERIODE', fom: '2024-01-01', tom: '2024-12-31' }],
+        visning: 'antall-over-tid',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      ukjenteKriterier: [],
+      harSensitiveISok: false,
+      initialResultat: {
+        kind: 'antall',
+        data: {
+          totalAntall: 1234,
+          buckets: Array.from({ length: 12 }, (_, i) => ({
+            periodeStart: `2024-${String(i + 1).padStart(2, '0')}-01`,
+            antall: 80 + Math.floor(Math.random() * 30),
+          })),
+        },
+      },
+      feilmelding: null,
+    }),
+}
+
+export const TomtResultat: Story = {
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling'],
+      metadata,
+      committed: {
+        behandlingType: 'AlderspensjonForstegangsbehandling',
+        ikkeSensitiveKriterier: [{ type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-03-31' }],
+        visning: 'treff',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      ukjenteKriterier: [],
+      harSensitiveISok: false,
+      initialResultat: { kind: 'treff', data: { treff: [], nesteCursor: null } },
+      feilmelding: null,
+    }),
+}
+
+export const UkjentKriterieIUrl: Story = {
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling'],
+      metadata,
+      committed: {
+        behandlingType: 'AlderspensjonForstegangsbehandling',
+        ikkeSensitiveKriterier: [],
+        visning: 'treff',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      harSensitiveISok: false,
+      ukjenteKriterier: [{ type: 'NYTT_FREMTIDIG_KRITERIUM', raw: {} }],
+      initialResultat: null,
+      feilmelding: null,
+    }),
+}
+
+export const BackendFeil: Story = {
+  tags: ['error-expected'],
+  render: () =>
+    renderWithLoader(BehandlingSokPage, {
+      typer: ['AlderspensjonForstegangsbehandling'],
+      metadata,
+      committed: {
+        behandlingType: 'AlderspensjonForstegangsbehandling',
+        ikkeSensitiveKriterier: [{ type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-03-31' }],
+        visning: 'treff',
+        aggregering: 'MAANED',
+        tidsdimensjon: 'OPPRETTET',
+      },
+      ukjenteKriterier: [],
+      harSensitiveISok: false,
+      initialResultat: null,
+      feilmelding: 'Søket overskred backend-grenser (max 100 verdier i IN-liste).',
+    }),
+}

--- a/app/behandling-sok/behandling-sok.tsx
+++ b/app/behandling-sok/behandling-sok.tsx
@@ -139,6 +139,7 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   const navigate = useNavigate()
   const fetcher = useFetcher<TreffResponse | { error: string }>()
   const antallFetcher = useFetcher<{ totalAntall: number; buckets: Bucket[] } | { error: string }>()
+  const metadataFetcher = useFetcher<BehandlingMetadata | { error: string }>()
   const [klientFeilmelding, setKlientFeilmelding] = useState<string | null>(null)
 
   const committedHash = useMemo(() => hashCommittedState(committed), [committed])
@@ -167,6 +168,27 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   const [draftVisning, setDraftVisning] = useState<Visning>(committed.visning)
   const [draftAggregering, setDraftAggregering] = useState<Aggregering>(committed.aggregering)
   const [draftTidsdimensjon, setDraftTidsdimensjon] = useState<Tidsdimensjon>(committed.tidsdimensjon)
+
+  // Hent metadata for valgt draft-behandlingstype slik at editorene viser riktige dropdowns
+  // (loaderens metadata speiler kun committed.behandlingType, så uten dette står editorene tomme
+  // til brukeren har kjørt søket).
+  const sisteFetchetType = useRef<string | null>(null)
+  useEffect(() => {
+    if (!draftBehandlingType) return
+    if (draftBehandlingType === committed.behandlingType) return
+    if (sisteFetchetType.current === draftBehandlingType) return
+    sisteFetchetType.current = draftBehandlingType
+    metadataFetcher.load(`/behandling-sok/api/metadata?type=${encodeURIComponent(draftBehandlingType)}`)
+  }, [draftBehandlingType, committed.behandlingType, metadataFetcher.load])
+
+  const draftMetadata = useMemo<BehandlingMetadata | null>(() => {
+    if (!draftBehandlingType) return null
+    if (draftBehandlingType === committed.behandlingType) return metadata
+    const data = metadataFetcher.data
+    if (data && !('error' in data) && data.behandlingType === draftBehandlingType) return data
+    return null
+  }, [draftBehandlingType, committed.behandlingType, metadata, metadataFetcher.data])
+  const draftMetadataFeil = metadataFetcher.data && 'error' in metadataFetcher.data ? metadataFetcher.data.error : null
 
   // Når committedSensitive lastes etter mount, oppdater draft hvis brukeren ikke har redigert noe ennå.
   const initialKriterierHashRef = useRef<string>(JSON.stringify(committed.ikkeSensitiveKriterier))
@@ -420,9 +442,15 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
             )}
           </HStack>
 
+          {draftMetadataFeil && (
+            <Alert variant="error" size="small">
+              Kunne ikke hente metadata for {draftBehandlingType}: {draftMetadataFeil}
+            </Alert>
+          )}
+
           <KriteriumListe
             kriterier={draftKriterier}
-            metadata={metadata}
+            metadata={draftMetadata}
             feil={validering.feil}
             onChange={setDraftKriterier}
           />

--- a/app/behandling-sok/behandling-sok.tsx
+++ b/app/behandling-sok/behandling-sok.tsx
@@ -417,7 +417,7 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
           {harUkjørteEndringer && <EndringerIkkeKjortBanner />}
 
           <HStack gap="space-12" align="center" wrap>
-            <KjorSokKnapp invalid={!kanKjore} onClick={kjørSøk} />
+            <KjorSokKnapp invalid={!kanKjore} harFeil={validering.feil.length > 0} onClick={kjørSøk} />
             <KopierJsonKnapp
               snapshot={{
                 schemaVersion: '1',

--- a/app/behandling-sok/behandling-sok.tsx
+++ b/app/behandling-sok/behandling-sok.tsx
@@ -1,0 +1,474 @@
+import {
+  Alert,
+  BodyShort,
+  Box,
+  Button,
+  ErrorSummary,
+  Heading,
+  HStack,
+  Page,
+  ToggleGroup,
+  VStack,
+} from '@navikt/ds-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useFetcher, useNavigate } from 'react-router'
+import { AnalyseErrorAlert } from '~/analyse/utils/AnalyseErrorAlert'
+import { apiPost } from '~/services/api.server'
+import type { Route } from './+types/behandling-sok'
+import type { TreffResponse } from './api.treff'
+import { AntallOverTidChart, type Bucket } from './components/AntallOverTidChart'
+import { AntallOverTidDataTabell } from './components/AntallOverTidDataTabell'
+import { BehandlingTypePicker } from './components/BehandlingTypePicker'
+import { EndringerIkkeKjortBanner } from './components/EndringerIkkeKjortBanner'
+import { KjorSokKnapp } from './components/KjorSokKnapp'
+import { KopierJsonKnapp } from './components/KopierJsonKnapp'
+import { KriteriumListe } from './components/KriteriumListe'
+import { LimInnJsonModal, type Snapshot } from './components/LimInnJsonModal'
+import { SensitiveVerdierBanner } from './components/SensitiveVerdierBanner'
+import { type Treff, TreffTabell } from './components/TreffTabell'
+import { type Kriterium, validerKriterier } from './lib/kriterier'
+import { buildAntallOverTidRequest, buildTreffRequest } from './lib/request-builder'
+import { hentSensitive, lagreSensitive, fjernSensitive as slettSensitiveStore } from './lib/sensitive-state'
+import {
+  type Aggregering,
+  ALLE_AGGREGERINGER,
+  ALLE_TIDSDIMENSJONER,
+  type CommittedState,
+  DEFAULT_STATE,
+  deserializeStateFromSearchParams,
+  fjernSensitive,
+  hashCommittedState,
+  plukkSensitive,
+  serializeStateToSearchParams,
+  type Tidsdimensjon,
+  type Visning,
+} from './lib/url-state'
+import { type BehandlingMetadata, hentBehandlingMetadata, hentBehandlingstyper } from './metadata-cache.server'
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: 'Behandlingssøk | Verdande' }]
+}
+
+type LoaderResult = {
+  typer: string[]
+  metadata: BehandlingMetadata | null
+  committed: CommittedState
+  ukjenteKriterier: { type: string; raw: unknown }[]
+  /** True når URL signaliserer at sensitive kriterier hører til søket — server hopper over initialt søk; klient gjør det. */
+  harSensitiveISok: boolean
+  initialResultat:
+    | { kind: 'treff'; data: TreffResponse }
+    | { kind: 'antall'; data: { totalAntall: number; buckets: Bucket[] } }
+    | null
+  feilmelding: string | null
+}
+
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderResult> {
+  const url = new URL(request.url)
+  const { state, ukjenteKriterier, feil: deserializeFeil } = deserializeStateFromSearchParams(url.searchParams)
+  const harSensitiveISok = url.searchParams.get('s') === '1'
+
+  const typer = await hentBehandlingstyper(request)
+
+  let metadata: BehandlingMetadata | null = null
+  if (state.behandlingType) {
+    try {
+      metadata = await hentBehandlingMetadata(state.behandlingType, request)
+    } catch (e) {
+      const status = (e as { data?: { status?: number } })?.data?.status ?? 500
+      if (status === 401 || status === 403) throw e
+      metadata = null
+    }
+  }
+
+  let initialResultat: LoaderResult['initialResultat'] = null
+  let feilmelding: string | null = deserializeFeil
+
+  // Hopp over server-side initialt søk hvis sensitive er en del av søket — klient må kombinere med sessionStorage først.
+  const skalKjøreServerSøk =
+    state.behandlingType &&
+    state.ikkeSensitiveKriterier.length > 0 &&
+    ukjenteKriterier.length === 0 &&
+    !harSensitiveISok
+
+  if (skalKjøreServerSøk && state.behandlingType) {
+    try {
+      if (state.visning === 'treff') {
+        const body = buildTreffRequest(state.behandlingType, state.ikkeSensitiveKriterier, null)
+        const res = await apiPost<TreffResponse>('/api/behandling/sok/treff', body, request)
+        initialResultat = { kind: 'treff', data: res as TreffResponse }
+      } else {
+        const body = buildAntallOverTidRequest(
+          state.behandlingType,
+          state.ikkeSensitiveKriterier,
+          state.aggregering,
+          state.tidsdimensjon,
+        )
+        const res = await apiPost<{ totalAntall: number; buckets: Bucket[] }>(
+          '/api/behandling/sok/antall-over-tid',
+          body,
+          request,
+        )
+        initialResultat = { kind: 'antall', data: res as { totalAntall: number; buckets: Bucket[] } }
+      }
+    } catch (e) {
+      const status = (e as { data?: { status?: number } })?.data?.status ?? 500
+      if (status === 401 || status === 403) throw e
+      const msg = (e as { data?: { detail?: string; title?: string } })?.data?.detail
+      feilmelding = msg ?? 'Søket feilet — sjekk kriteriene.'
+    }
+  }
+
+  return {
+    typer,
+    metadata,
+    committed: { ...DEFAULT_STATE, ...state },
+    ukjenteKriterier,
+    harSensitiveISok,
+    initialResultat,
+    feilmelding,
+  }
+}
+
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  return <AnalyseErrorAlert error={error} label="Behandlingssøk feilet" />
+}
+
+export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) {
+  const { typer, metadata, committed, ukjenteKriterier, harSensitiveISok, initialResultat, feilmelding } = loaderData
+  const navigate = useNavigate()
+  const fetcher = useFetcher<TreffResponse | { error: string }>()
+  const antallFetcher = useFetcher<{ totalAntall: number; buckets: Bucket[] } | { error: string }>()
+
+  const committedHash = useMemo(() => hashCommittedState(committed), [committed])
+
+  // ─── Committed sensitive kriterier (lest fra sessionStorage etter mount) ───
+  const [committedSensitive, setCommittedSensitive] = useState<Kriterium[]>([])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    setCommittedSensitive(harSensitiveISok ? hentSensitive(committedHash) : [])
+  }, [committedHash, harSensitiveISok])
+
+  // Fullstendig committed-kriterieliste (ikke-sensitive fra URL + sensitive fra sessionStorage)
+  const committedKriterier = useMemo<Kriterium[]>(
+    () => [...committed.ikkeSensitiveKriterier, ...committedSensitive],
+    [committed.ikkeSensitiveKriterier, committedSensitive],
+  )
+
+  // ─── Draft-state (alt brukeren redigerer) ───
+  const [draftBehandlingType, setDraftBehandlingType] = useState<string | null>(committed.behandlingType)
+  const [draftKriterier, setDraftKriterier] = useState<Kriterium[]>(committedKriterier)
+  const [draftVisning, setDraftVisning] = useState<Visning>(committed.visning)
+  const [draftAggregering, setDraftAggregering] = useState<Aggregering>(committed.aggregering)
+  const [draftTidsdimensjon, setDraftTidsdimensjon] = useState<Tidsdimensjon>(committed.tidsdimensjon)
+
+  // Når committedSensitive lastes etter mount, oppdater draft hvis brukeren ikke har redigert noe ennå.
+  const initialKriterierHashRef = useRef<string>(JSON.stringify(committed.ikkeSensitiveKriterier))
+  useEffect(() => {
+    if (committedSensitive.length === 0) return
+    if (JSON.stringify(draftKriterier) === initialKriterierHashRef.current) {
+      setDraftKriterier([...committed.ikkeSensitiveKriterier, ...committedSensitive])
+    }
+  }, [committedSensitive, committed.ikkeSensitiveKriterier, draftKriterier])
+
+  // ─── Akkumulerte resultater (paginering for treff, eller klient-fetched for sensitive-søk) ───
+  const initialTreff = useMemo<Treff[]>(
+    () => (initialResultat?.kind === 'treff' ? initialResultat.data.treff : []),
+    [initialResultat],
+  )
+  const initialNesteCursor = useMemo(
+    () => (initialResultat?.kind === 'treff' ? initialResultat.data.nesteCursor : null),
+    [initialResultat],
+  )
+  const initialAntall = useMemo<{ totalAntall: number; buckets: Bucket[] }>(
+    () => (initialResultat?.kind === 'antall' ? initialResultat.data : { totalAntall: 0, buckets: [] }),
+    [initialResultat],
+  )
+
+  const [akkumulerteTreff, setAkkumulerteTreff] = useState<Treff[]>(initialTreff)
+  const [nesteCursor, setNesteCursor] = useState(initialNesteCursor)
+  const [klientAntall, setKlientAntall] = useState(initialAntall)
+
+  // Reset når committed-hash endres (ny URL).
+  useEffect(() => {
+    setAkkumulerteTreff(initialTreff)
+    setNesteCursor(initialNesteCursor)
+    setKlientAntall(initialAntall)
+  }, [initialAntall, initialNesteCursor, initialTreff])
+
+  // Klient-side initialt søk når sensitive er en del av query (loaderen hoppet over).
+  const venterPaInitialSensitiveLoad = useRef(false)
+  useEffect(() => {
+    if (!harSensitiveISok) return
+    if (committedSensitive.length === 0) return // venter på lasting fra sessionStorage
+    if (!committed.behandlingType) return
+    venterPaInitialSensitiveLoad.current = committed.visning === 'treff'
+    if (committed.visning === 'treff') {
+      const body = buildTreffRequest(committed.behandlingType, committedKriterier, null)
+      fetcher.submit(body, { method: 'post', action: '/behandling-sok/api/treff', encType: 'application/json' })
+    } else {
+      const body = buildAntallOverTidRequest(
+        committed.behandlingType,
+        committedKriterier,
+        committed.aggregering,
+        committed.tidsdimensjon,
+      )
+      antallFetcher.submit(body, {
+        method: 'post',
+        action: '/behandling-sok/api/antall',
+        encType: 'application/json',
+      })
+    }
+  }, [
+    committedSensitive,
+    antallFetcher.submit,
+    committed.aggregering,
+    committed.behandlingType,
+    committed.tidsdimensjon,
+    committed.visning,
+    committedKriterier,
+    fetcher.submit,
+    harSensitiveISok,
+  ])
+
+  // Akkumuler treff fra fetcher
+  useEffect(() => {
+    if (!fetcher.data) return
+    if ('treff' in fetcher.data) {
+      const data = fetcher.data
+      const erstatt = venterPaInitialSensitiveLoad.current
+      venterPaInitialSensitiveLoad.current = false
+      setAkkumulerteTreff((prev) => (erstatt ? data.treff : [...prev, ...data.treff]))
+      setNesteCursor(data.nesteCursor)
+    }
+  }, [fetcher.data])
+
+  useEffect(() => {
+    if (!antallFetcher.data) return
+    if ('buckets' in antallFetcher.data) {
+      setKlientAntall(antallFetcher.data)
+    }
+  }, [antallFetcher.data])
+
+  const validering = useMemo(() => validerKriterier(draftKriterier), [draftKriterier])
+  const harUkjenteIUrl = ukjenteKriterier.length > 0
+  const kanKjore =
+    !validering.manglerTidsfilter && validering.feil.length === 0 && !!draftBehandlingType && !harUkjenteIUrl
+  const errorSummaryRef = useRef<HTMLDivElement>(null)
+
+  const kjørSøk = useCallback(() => {
+    if (!kanKjore) {
+      errorSummaryRef.current?.focus()
+      return
+    }
+    const ikkeSensitive = fjernSensitive(draftKriterier)
+    const sensitive = plukkSensitive(draftKriterier)
+    const newCommitted: CommittedState = {
+      behandlingType: draftBehandlingType,
+      ikkeSensitiveKriterier: ikkeSensitive,
+      visning: draftVisning,
+      aggregering: draftAggregering,
+      tidsdimensjon: draftTidsdimensjon,
+    }
+    const hash = hashCommittedState(newCommitted)
+    if (sensitive.length > 0) {
+      lagreSensitive(hash, sensitive)
+    } else {
+      slettSensitiveStore(hash)
+    }
+    const sp = serializeStateToSearchParams({
+      behandlingType: draftBehandlingType,
+      kriterier: draftKriterier,
+      visning: draftVisning,
+      aggregering: draftAggregering,
+      tidsdimensjon: draftTidsdimensjon,
+    })
+    if (sensitive.length > 0) sp.set('s', '1')
+    navigate(`/behandling-sok?${sp.toString()}`)
+  }, [kanKjore, draftKriterier, draftBehandlingType, draftVisning, draftAggregering, draftTidsdimensjon, navigate])
+
+  const draftHash = useMemo(
+    () =>
+      hashCommittedState({
+        behandlingType: draftBehandlingType,
+        ikkeSensitiveKriterier: fjernSensitive(draftKriterier),
+        visning: draftVisning,
+        aggregering: draftAggregering,
+        tidsdimensjon: draftTidsdimensjon,
+      }),
+    [draftBehandlingType, draftKriterier, draftVisning, draftAggregering, draftTidsdimensjon],
+  )
+  const draftSensitiveHash = useMemo(() => JSON.stringify(plukkSensitive(draftKriterier)), [draftKriterier])
+  const committedSensitiveHash = useMemo(() => JSON.stringify(committedSensitive), [committedSensitive])
+  const harUkjørteEndringer = draftHash !== committedHash || draftSensitiveHash !== committedSensitiveHash
+
+  const harSensitive = plukkSensitive(draftKriterier).length > 0
+
+  const lastMer = useCallback(() => {
+    if (!nesteCursor || !committed.behandlingType) return
+    if (harUkjørteEndringer) return
+    const body = buildTreffRequest(committed.behandlingType, committedKriterier, nesteCursor)
+    fetcher.submit(body, {
+      method: 'post',
+      action: '/behandling-sok/api/treff',
+      encType: 'application/json',
+    })
+  }, [nesteCursor, committed.behandlingType, committedKriterier, harUkjørteEndringer, fetcher])
+
+  const [limInnOpen, setLimInnOpen] = useState(false)
+
+  // Vise-data: foretrekk klient-resultat når det finnes (sensitive-søk), ellers initial.
+  const visTreff = initialResultat?.kind === 'treff' || (harSensitiveISok && committed.visning === 'treff')
+  const visAntall = initialResultat?.kind === 'antall' || (harSensitiveISok && committed.visning === 'antall-over-tid')
+  const antallData = initialResultat?.kind === 'antall' ? initialResultat.data : klientAntall
+
+  return (
+    <Page>
+      <Page.Block width="2xl" gutters>
+        <VStack gap="space-24">
+          <Heading level="1" size="large">
+            Behandlingssøk
+          </Heading>
+          <BodyShort>
+            Bygg generiske kriteriebaserte søk mot behandlingsbeholdningen. Velg behandlingstype, legg til kriterier (★
+            = tidsfilter, kreves), og velg om du vil se treff eller antall over tid.
+          </BodyShort>
+
+          {harUkjenteIUrl && (
+            <Alert variant="error">
+              URL-en inneholder ukjente kriterietyper: <strong>{ukjenteKriterier.map((u) => u.type).join(', ')}</strong>
+              . Søket er blokkert til ukjente kriterier er fjernet fra URL-en. Oppdater Verdande hvis du forventer å
+              bruke disse typene, eller fjern <code>?q=</code> fra adressen for å starte på nytt.
+            </Alert>
+          )}
+
+          {feilmelding && <Alert variant="error">{feilmelding}</Alert>}
+
+          {harSensitive && <SensitiveVerdierBanner />}
+
+          <HStack gap="space-16" align="end" wrap>
+            <BehandlingTypePicker typer={typer} valgt={draftBehandlingType} onChange={setDraftBehandlingType} />
+            <ToggleGroup
+              size="small"
+              label="Visning"
+              value={draftVisning}
+              onChange={(v) => setDraftVisning(v as Visning)}
+            >
+              <ToggleGroup.Item value="treff">Treff (tabell)</ToggleGroup.Item>
+              <ToggleGroup.Item value="antall-over-tid">Antall over tid</ToggleGroup.Item>
+            </ToggleGroup>
+            {draftVisning === 'antall-over-tid' && (
+              <>
+                <ToggleGroup
+                  size="small"
+                  label="Aggregering"
+                  value={draftAggregering}
+                  onChange={(v) => setDraftAggregering(v as Aggregering)}
+                >
+                  {ALLE_AGGREGERINGER.map((a) => (
+                    <ToggleGroup.Item key={a} value={a}>
+                      {a}
+                    </ToggleGroup.Item>
+                  ))}
+                </ToggleGroup>
+                <ToggleGroup
+                  size="small"
+                  label="Tidsdimensjon"
+                  value={draftTidsdimensjon}
+                  onChange={(v) => setDraftTidsdimensjon(v as Tidsdimensjon)}
+                >
+                  {ALLE_TIDSDIMENSJONER.map((t) => (
+                    <ToggleGroup.Item key={t} value={t}>
+                      {t}
+                    </ToggleGroup.Item>
+                  ))}
+                </ToggleGroup>
+              </>
+            )}
+          </HStack>
+
+          <KriteriumListe
+            kriterier={draftKriterier}
+            metadata={metadata}
+            feil={validering.feil}
+            onChange={setDraftKriterier}
+          />
+
+          {validering.manglerTidsfilter && draftKriterier.length > 0 && (
+            <Alert variant="warning" size="small">
+              Minst ett tids-kriterium (★) kreves.
+            </Alert>
+          )}
+
+          {validering.feil.length > 0 && (
+            <ErrorSummary ref={errorSummaryRef} heading="Det er feil i ett eller flere kriterier:">
+              {validering.feil.map((f, i) => (
+                <ErrorSummary.Item key={`${f.kriterieIndeks}-${f.felt}-${i}`} href={`#kriterium-${f.kriterieIndeks}`}>
+                  Kriterium #{f.kriterieIndeks + 1}: {f.melding}
+                </ErrorSummary.Item>
+              ))}
+            </ErrorSummary>
+          )}
+
+          {harUkjørteEndringer && <EndringerIkkeKjortBanner />}
+
+          <HStack gap="space-12" align="center" wrap>
+            <KjorSokKnapp invalid={!kanKjore} onClick={kjørSøk} />
+            <KopierJsonKnapp
+              snapshot={{
+                schemaVersion: '1',
+                behandlingType: draftBehandlingType,
+                visning: draftVisning,
+                aggregering: draftAggregering,
+                tidsdimensjon: draftTidsdimensjon,
+                kriterier: draftKriterier,
+              }}
+            />
+            <Button size="small" variant="tertiary" onClick={() => setLimInnOpen(true)}>
+              Lim inn JSON
+            </Button>
+          </HStack>
+
+          <LimInnJsonModal
+            open={limInnOpen}
+            onClose={() => setLimInnOpen(false)}
+            onApply={(snap: Snapshot) => {
+              if (snap.behandlingType !== undefined) setDraftBehandlingType(snap.behandlingType)
+              if (snap.visning) setDraftVisning(snap.visning)
+              if (snap.aggregering) setDraftAggregering(snap.aggregering)
+              if (snap.tidsdimensjon) setDraftTidsdimensjon(snap.tidsdimensjon)
+              setDraftKriterier(snap.kriterier)
+            }}
+          />
+
+          <Box aria-live="polite">
+            {visTreff && (
+              <TreffTabell
+                treff={akkumulerteTreff}
+                totalAntallVist={akkumulerteTreff.length}
+                nesteCursor={nesteCursor}
+                isLoadingMore={fetcher.state !== 'idle'}
+                paginringDisabledFordiUkjorteEndringer={harUkjørteEndringer}
+                onLastMer={lastMer}
+              />
+            )}
+            {visAntall && (
+              <VStack gap="space-12">
+                <BodyShort>Totalt antall: {antallData.totalAntall.toLocaleString('nb-NO')}</BodyShort>
+                <AntallOverTidChart
+                  buckets={antallData.buckets}
+                  aggregering={committed.aggregering}
+                  tidsdimensjon={committed.tidsdimensjon}
+                />
+                <details>
+                  <summary>Vis som tabell</summary>
+                  <AntallOverTidDataTabell buckets={antallData.buckets} aggregering={committed.aggregering} />
+                </details>
+              </VStack>
+            )}
+          </Box>
+        </VStack>
+      </Page.Block>
+    </Page>
+  )
+}

--- a/app/behandling-sok/behandling-sok.tsx
+++ b/app/behandling-sok/behandling-sok.tsx
@@ -205,7 +205,11 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
     venterPaInitialSensitiveLoad.current = committed.visning === 'treff'
     if (committed.visning === 'treff') {
       const body = buildTreffRequest(committed.behandlingType, committedKriterier, null)
-      fetcher.submit(body, { method: 'post', action: '/behandling-sok/api/treff', encType: 'application/json' })
+      fetcher.submit(body as never, {
+        method: 'post',
+        action: '/behandling-sok/api/treff',
+        encType: 'application/json',
+      })
     } else {
       const body = buildAntallOverTidRequest(
         committed.behandlingType,
@@ -213,7 +217,7 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
         committed.aggregering,
         committed.tidsdimensjon,
       )
-      antallFetcher.submit(body, {
+      antallFetcher.submit(body as never, {
         method: 'post',
         action: '/behandling-sok/api/antall',
         encType: 'application/json',
@@ -308,7 +312,7 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
     if (!nesteCursor || !committed.behandlingType) return
     if (harUkjørteEndringer) return
     const body = buildTreffRequest(committed.behandlingType, committedKriterier, nesteCursor)
-    fetcher.submit(body, {
+    fetcher.submit(body as never, {
       method: 'post',
       action: '/behandling-sok/api/treff',
       encType: 'application/json',

--- a/app/behandling-sok/behandling-sok.tsx
+++ b/app/behandling-sok/behandling-sok.tsx
@@ -139,15 +139,21 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   const navigate = useNavigate()
   const fetcher = useFetcher<TreffResponse | { error: string }>()
   const antallFetcher = useFetcher<{ totalAntall: number; buckets: Bucket[] } | { error: string }>()
+  const [klientFeilmelding, setKlientFeilmelding] = useState<string | null>(null)
 
   const committedHash = useMemo(() => hashCommittedState(committed), [committed])
 
   // ─── Committed sensitive kriterier (lest fra sessionStorage etter mount) ───
   const [committedSensitive, setCommittedSensitive] = useState<Kriterium[]>([])
+  const [sensitiveLastet, setSensitiveLastet] = useState(false)
   useEffect(() => {
     if (typeof window === 'undefined') return
     setCommittedSensitive(harSensitiveISok ? hentSensitive(committedHash) : [])
+    setSensitiveLastet(true)
   }, [committedHash, harSensitiveISok])
+
+  // Sensitive del av URL, men ingen treff i sessionStorage (ny fane / refresh / delt lenke).
+  const sensitiveMangler = harSensitiveISok && sensitiveLastet && committedSensitive.length === 0
 
   // Fullstendig committed-kriterieliste (ikke-sensitive fra URL + sensitive fra sessionStorage)
   const committedKriterier = useMemo<Kriterium[]>(
@@ -200,7 +206,7 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   const venterPaInitialSensitiveLoad = useRef(false)
   useEffect(() => {
     if (!harSensitiveISok) return
-    if (committedSensitive.length === 0) return // venter på lasting fra sessionStorage
+    if (committedSensitive.length === 0) return // venter på lasting fra sessionStorage, eller mangler helt
     if (!committed.behandlingType) return
     venterPaInitialSensitiveLoad.current = committed.visning === 'treff'
     if (committed.visning === 'treff') {
@@ -238,7 +244,13 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   // Akkumuler treff fra fetcher
   useEffect(() => {
     if (!fetcher.data) return
+    if ('error' in fetcher.data) {
+      setKlientFeilmelding(fetcher.data.error)
+      venterPaInitialSensitiveLoad.current = false
+      return
+    }
     if ('treff' in fetcher.data) {
+      setKlientFeilmelding(null)
       const data = fetcher.data
       const erstatt = venterPaInitialSensitiveLoad.current
       venterPaInitialSensitiveLoad.current = false
@@ -249,7 +261,12 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
 
   useEffect(() => {
     if (!antallFetcher.data) return
+    if ('error' in antallFetcher.data) {
+      setKlientFeilmelding(antallFetcher.data.error)
+      return
+    }
     if ('buckets' in antallFetcher.data) {
+      setKlientFeilmelding(null)
       setKlientAntall(antallFetcher.data)
     }
   }, [antallFetcher.data])
@@ -322,8 +339,11 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
   const [limInnOpen, setLimInnOpen] = useState(false)
 
   // Vise-data: foretrekk klient-resultat når det finnes (sensitive-søk), ellers initial.
-  const visTreff = initialResultat?.kind === 'treff' || (harSensitiveISok && committed.visning === 'treff')
-  const visAntall = initialResultat?.kind === 'antall' || (harSensitiveISok && committed.visning === 'antall-over-tid')
+  const visTreff =
+    !sensitiveMangler && (initialResultat?.kind === 'treff' || (harSensitiveISok && committed.visning === 'treff'))
+  const visAntall =
+    !sensitiveMangler &&
+    (initialResultat?.kind === 'antall' || (harSensitiveISok && committed.visning === 'antall-over-tid'))
   const antallData = initialResultat?.kind === 'antall' ? initialResultat.data : klientAntall
 
   return (
@@ -347,6 +367,15 @@ export default function BehandlingSokPage({ loaderData }: Route.ComponentProps) 
           )}
 
           {feilmelding && <Alert variant="error">{feilmelding}</Alert>}
+
+          {klientFeilmelding && <Alert variant="error">{klientFeilmelding}</Alert>}
+
+          {sensitiveMangler && (
+            <Alert variant="warning">
+              Søket inneholder sensitive kriterier (NAV-identer eller behandlingsserie-UUID) som ble lagret lokalt og
+              ikke ligger i URL-en. De er ikke tilgjengelige i denne fanen — kjør søket på nytt med kriteriene fylt inn.
+            </Alert>
+          )}
 
           {harSensitive && <SensitiveVerdierBanner />}
 

--- a/app/behandling-sok/components/AntallOverTidChart.tsx
+++ b/app/behandling-sok/components/AntallOverTidChart.tsx
@@ -1,0 +1,60 @@
+import type { ChartData, ChartOptions } from 'chart.js'
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip,
+} from 'chart.js'
+import { useMemo } from 'react'
+import { Bar, Line } from 'react-chartjs-2'
+import { formaterBucketLabel, tidsdimensjonLabel } from '../lib/formatters'
+import type { Aggregering, Tidsdimensjon } from '../lib/url-state'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend)
+
+export type Bucket = { periodeStart: string; antall: number }
+
+type Props = {
+  buckets: Bucket[]
+  aggregering: Aggregering
+  tidsdimensjon: Tidsdimensjon
+}
+
+const COLOR = 'rgba(0, 96, 165, 0.7)'
+
+export function AntallOverTidChart({ buckets, aggregering, tidsdimensjon }: Props) {
+  const useLine = buckets.length > 60
+  const chartData = useMemo(() => {
+    const labels = buckets.map((b) => formaterBucketLabel(b.periodeStart, aggregering))
+    const data = buckets.map((b) => b.antall)
+    const ds = {
+      label: `Antall behandlinger (${tidsdimensjonLabel(tidsdimensjon).toLowerCase()})`,
+      data,
+      backgroundColor: COLOR,
+      borderColor: COLOR,
+      borderWidth: 1,
+    }
+    return { labels, datasets: [ds] } as ChartData<'bar' | 'line', number[], string>
+  }, [buckets, aggregering, tidsdimensjon])
+
+  const options: ChartOptions<'bar' | 'line'> = {
+    plugins: {
+      title: { display: true, text: `Antall over tid — aggregert per ${aggregering.toLowerCase()}` },
+      legend: { position: 'bottom' },
+    },
+    responsive: true,
+    scales: {
+      y: { beginAtZero: true, ticks: { precision: 0 } },
+    },
+  }
+
+  if (useLine) {
+    return <Line data={chartData as ChartData<'line', number[], string>} options={options as ChartOptions<'line'>} />
+  }
+  return <Bar data={chartData as ChartData<'bar', number[], string>} options={options as ChartOptions<'bar'>} />
+}

--- a/app/behandling-sok/components/AntallOverTidDataTabell.tsx
+++ b/app/behandling-sok/components/AntallOverTidDataTabell.tsx
@@ -1,0 +1,30 @@
+import { Table } from '@navikt/ds-react'
+import { formaterBucketLabel } from '../lib/formatters'
+import type { Aggregering } from '../lib/url-state'
+import type { Bucket } from './AntallOverTidChart'
+
+type Props = {
+  buckets: Bucket[]
+  aggregering: Aggregering
+}
+
+export function AntallOverTidDataTabell({ buckets, aggregering }: Props) {
+  return (
+    <Table size="small">
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Periode</Table.HeaderCell>
+          <Table.HeaderCell align="right">Antall</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {buckets.map((b) => (
+          <Table.Row key={b.periodeStart}>
+            <Table.DataCell>{formaterBucketLabel(b.periodeStart, aggregering)}</Table.DataCell>
+            <Table.DataCell align="right">{b.antall.toLocaleString('nb-NO')}</Table.DataCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  )
+}

--- a/app/behandling-sok/components/BehandlingTypePicker.tsx
+++ b/app/behandling-sok/components/BehandlingTypePicker.tsx
@@ -1,0 +1,23 @@
+import { UNSAFE_Combobox } from '@navikt/ds-react'
+
+type Props = {
+  typer: string[]
+  valgt: string | null
+  onChange: (type: string | null) => void
+}
+
+export function BehandlingTypePicker({ typer, valgt, onChange }: Props) {
+  return (
+    <UNSAFE_Combobox
+      label="Behandlingstype"
+      size="small"
+      options={typer.map((t) => ({ label: t, value: t }))}
+      selectedOptions={valgt ? [valgt] : []}
+      shouldAutocomplete
+      onToggleSelected={(option, isSelected) => {
+        if (isSelected) onChange(option)
+        else onChange(null)
+      }}
+    />
+  )
+}

--- a/app/behandling-sok/components/EndringerIkkeKjortBanner.tsx
+++ b/app/behandling-sok/components/EndringerIkkeKjortBanner.tsx
@@ -1,0 +1,9 @@
+import { Alert } from '@navikt/ds-react'
+
+export function EndringerIkkeKjortBanner() {
+  return (
+    <Alert variant="info" size="small" inline>
+      Du har ulagrede endringer i kriteriene. Trykk «Kjør søk» for å oppdatere resultatene.
+    </Alert>
+  )
+}

--- a/app/behandling-sok/components/KjorSokKnapp.tsx
+++ b/app/behandling-sok/components/KjorSokKnapp.tsx
@@ -1,0 +1,14 @@
+import { Button } from '@navikt/ds-react'
+
+type Props = {
+  invalid: boolean
+  onClick: () => void
+}
+
+export function KjorSokKnapp({ invalid, onClick }: Props) {
+  return (
+    <Button variant="primary" size="small" onClick={onClick}>
+      {invalid ? 'Vis valideringsfeil' : 'Kjør søk'}
+    </Button>
+  )
+}

--- a/app/behandling-sok/components/KjorSokKnapp.tsx
+++ b/app/behandling-sok/components/KjorSokKnapp.tsx
@@ -2,13 +2,14 @@ import { Button } from '@navikt/ds-react'
 
 type Props = {
   invalid: boolean
+  harFeil: boolean
   onClick: () => void
 }
 
-export function KjorSokKnapp({ invalid, onClick }: Props) {
+export function KjorSokKnapp({ invalid, harFeil, onClick }: Props) {
   return (
-    <Button variant="primary" size="small" onClick={onClick}>
-      {invalid ? 'Vis valideringsfeil' : 'Kjør søk'}
+    <Button variant="primary" size="small" onClick={onClick} disabled={invalid && !harFeil}>
+      {harFeil ? 'Vis valideringsfeil' : 'Kjør søk'}
     </Button>
   )
 }

--- a/app/behandling-sok/components/KopierJsonKnapp.tsx
+++ b/app/behandling-sok/components/KopierJsonKnapp.tsx
@@ -1,0 +1,22 @@
+import { CopyButton, HStack } from '@navikt/ds-react'
+import type { Kriterium } from '../lib/kriterier'
+import type { Aggregering, Tidsdimensjon, Visning } from '../lib/url-state'
+
+type Snapshot = {
+  schemaVersion: '1'
+  behandlingType: string | null
+  visning: Visning
+  aggregering: Aggregering
+  tidsdimensjon: Tidsdimensjon
+  kriterier: Kriterium[]
+}
+
+export function KopierJsonKnapp({ snapshot }: { snapshot: Snapshot }) {
+  // CopyButton kopierer activeText. Vi serialiserer til klargjort JSON.
+  const text = JSON.stringify(snapshot, null, 2)
+  return (
+    <HStack gap="space-8" align="center">
+      <CopyButton size="small" copyText={text} text="Kopiér som JSON" activeText="Kopiert!" variant="action" />
+    </HStack>
+  )
+}

--- a/app/behandling-sok/components/KriteriumDispatcher.tsx
+++ b/app/behandling-sok/components/KriteriumDispatcher.tsx
@@ -1,0 +1,232 @@
+import { BodyShort, Box, Button, Heading, HStack, VStack } from '@navikt/ds-react'
+import type { Kriterium } from '../lib/kriterier'
+import { KRITERIE_DEFINISJONER, type Valideringsfeil } from '../lib/kriterier'
+import type { BehandlingMetadata } from '../metadata-cache.server'
+import { CheckboxEditor } from './editors/CheckboxEditor'
+import { MultiSelectEditor } from './editors/MultiSelectEditor'
+import { MultiSelectMedOperatorEditor } from './editors/MultiSelectMedOperatorEditor'
+import { MultiTallEditor } from './editors/MultiTallEditor'
+import { PeriodeEditor } from './editors/PeriodeEditor'
+import { TagInputEditor } from './editors/TagInputEditor'
+import { TallEditor } from './editors/TallEditor'
+import { ToggleEditor } from './editors/ToggleEditor'
+import { UuidEditor } from './editors/UuidEditor'
+import { ValgfriDatoEditor } from './editors/ValgfriDatoEditor'
+
+type Props = {
+  kriterium: Kriterium
+  indeks: number
+  metadata: BehandlingMetadata | null
+  feilForKriterium: Valideringsfeil[]
+  onChange: (k: Kriterium) => void
+  onFjern: () => void
+}
+
+/**
+ * Dispatcher fra `Kriterium['type']` til riktig editor-komponent.
+ * Renderer en fieldset med visningsnavn + fjern-knapp + selve editoren.
+ */
+export function KriteriumDispatcher({ kriterium, indeks, metadata, feilForKriterium, onChange, onFjern }: Props) {
+  const def = KRITERIE_DEFINISJONER[kriterium.type]
+  const feilString = feilForKriterium.map((f) => f.melding).join(', ') || undefined
+
+  return (
+    <Box as="section" id={`kriterium-${indeks}`} background="raised" borderRadius="4" padding="space-16" tabIndex={-1}>
+      <VStack gap="space-12">
+        <HStack justify="space-between" align="center">
+          <Heading level="3" size="xsmall">
+            {def.visningsnavn}
+          </Heading>
+          <Button variant="tertiary" size="small" onClick={onFjern}>
+            Fjern
+          </Button>
+        </HStack>
+        {renderEditor(kriterium, metadata, feilString, onChange)}
+      </VStack>
+    </Box>
+  )
+}
+
+function renderEditor(
+  kriterium: Kriterium,
+  metadata: BehandlingMetadata | null,
+  feil: string | undefined,
+  onChange: (k: Kriterium) => void,
+) {
+  switch (kriterium.type) {
+    case 'OPPRETTET_I_PERIODE':
+    case 'FULLFORT_I_PERIODE':
+    case 'STOPPET_I_PERIODE':
+    case 'SIST_KJORT_I_PERIODE':
+      return <PeriodeEditor kriterium={kriterium} onChange={onChange} />
+
+    case 'HAR_STATUS':
+      return (
+        <MultiSelectEditor
+          label="Behandlingsstatus"
+          alternativer={metadata?.behandlingStatuser ?? []}
+          valgte={kriterium.statuser}
+          onChange={(nye) => onChange({ ...kriterium, statuser: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'KRAVHODE_HAR_STATUS':
+      return (
+        <MultiSelectEditor
+          label="Kravstatus"
+          alternativer={metadata?.kravStatuser ?? []}
+          valgte={kriterium.statuser}
+          onChange={(nye) => onChange({ ...kriterium, statuser: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'HAR_ANSVARLIG_TEAM':
+      return (
+        <MultiSelectEditor
+          label="Ansvarlig team"
+          alternativer={metadata?.ansvarligeTeam ?? []}
+          valgte={kriterium.team}
+          onChange={(nye) => onChange({ ...kriterium, team: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'KRAV_GJELDER':
+      return (
+        <MultiSelectEditor
+          label="Krav gjelder"
+          alternativer={metadata?.kravGjelderKoder ?? []}
+          valgte={kriterium.koder}
+          onChange={(nye) => onChange({ ...kriterium, koder: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'SAK_HAR_TYPE':
+      return (
+        <MultiSelectEditor
+          label="Sakstype"
+          alternativer={metadata?.sakstyper ?? []}
+          valgte={kriterium.sakstyper}
+          onChange={(nye) => onChange({ ...kriterium, sakstyper: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'KRAV_HAR_EIERENHET':
+      return (
+        <MultiSelectEditor
+          label="Eierenhet"
+          alternativer={metadata?.eierenheter ?? []}
+          valgte={kriterium.eierenheter}
+          onChange={(nye) => onChange({ ...kriterium, eierenheter: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'HAR_AKTIVITET_AV_TYPE': {
+      const supported = metadata?.supportedAktivitetTyper ?? []
+      const observed = metadata?.observedAktivitetTyper ?? []
+      const historiske = observed.filter((o) => !supported.includes(o))
+      return (
+        <MultiSelectMedOperatorEditor
+          label="Aktivitetstype"
+          alternativer={supported}
+          historiske={historiske}
+          valgte={kriterium.aktivitetTyper}
+          operator={kriterium.operator}
+          onChange={({ valgte, operator }) => onChange({ ...kriterium, aktivitetTyper: valgte, operator })}
+          feil={feil}
+        />
+      )
+    }
+
+    case 'KRAVHODE_HAR_KONTROLLPUNKT': {
+      const koder = (metadata?.kontrollpunktTyper ?? []).map((k) => k.kode)
+      return (
+        <MultiSelectMedOperatorEditor
+          label="Kontrollpunkt"
+          alternativer={koder}
+          valgte={kriterium.kontrollpunktTyper}
+          operator={kriterium.operator}
+          onChange={({ valgte, operator }) => onChange({ ...kriterium, kontrollpunktTyper: valgte, operator })}
+          feil={feil}
+        />
+      )
+    }
+
+    case 'OPPRETTET_AV':
+      return (
+        <TagInputEditor
+          label="NAV-identer"
+          identer={kriterium.identer}
+          onChange={(nye) => onChange({ ...kriterium, identer: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'TILHORER_BEHANDLINGSSERIE':
+      return (
+        <UuidEditor
+          label="Behandlingsserie-UUID"
+          uuid={kriterium.uuid}
+          onChange={(uuid) => onChange({ ...kriterium, uuid })}
+          feil={feil}
+        />
+      )
+
+    case 'HAR_PRIORITET':
+      return (
+        <MultiTallEditor
+          label="Prioritet(er)"
+          prioriteter={kriterium.prioriteter}
+          onChange={(nye) => onChange({ ...kriterium, prioriteter: nye })}
+          feil={feil}
+        />
+      )
+
+    case 'AKTIVITET_KJORT_FLERE_GANGER_ENN':
+      return (
+        <TallEditor
+          label="Antall kjøringer"
+          verdi={kriterium.terskel}
+          onChange={(n) => onChange({ ...kriterium, terskel: n })}
+          feil={feil}
+        />
+      )
+
+    case 'ER_BATCH':
+      return (
+        <ToggleEditor
+          label="Er batch-behandling"
+          verdi={kriterium.verdi}
+          onChange={(v) => onChange({ ...kriterium, verdi: v })}
+        />
+      )
+
+    case 'HAR_FEILET_KJORING':
+      return (
+        <ValgfriDatoEditor
+          label="Siden (valgfritt)"
+          verdi={kriterium.siden}
+          onChange={(v) => onChange({ ...kriterium, siden: v })}
+          feil={feil}
+        />
+      )
+
+    case 'HAR_AAPEN_MANUELL_BEHANDLING':
+      return <CheckboxEditor beskrivelse="Filtrerer på behandlinger som har en åpen manuell behandling-aktivitet." />
+    case 'HAR_AAPEN_BREVBESTILLING':
+      return <CheckboxEditor beskrivelse="Filtrerer på behandlinger som har en åpen brevbestilling-aktivitet." />
+    case 'KONTROLLPUNKT_ER_KRITISK':
+      return <CheckboxEditor beskrivelse="Filtrerer på krav med minst ett kritisk kontrollpunkt." />
+
+    default: {
+      // exhaustive check
+      const _exhaustive: never = kriterium
+      return <BodyShort>{`Ukjent kriterium: ${JSON.stringify(_exhaustive)}`}</BodyShort>
+    }
+  }
+}

--- a/app/behandling-sok/components/KriteriumDispatcher.tsx
+++ b/app/behandling-sok/components/KriteriumDispatcher.tsx
@@ -157,6 +157,17 @@ function renderEditor(
       )
     }
 
+    case 'KRAVHODE_HAR_BEHANDLINGTYPE':
+      return (
+        <MultiSelectEditor
+          label="Kravhodets behandlingstype"
+          alternativer={metadata?.kravhodeBehandlingTyper ?? []}
+          valgte={kriterium.behandlingTyper}
+          onChange={(nye) => onChange({ ...kriterium, behandlingTyper: nye })}
+          feil={feil}
+        />
+      )
+
     case 'OPPRETTET_AV':
       return (
         <TagInputEditor

--- a/app/behandling-sok/components/KriteriumListe.tsx
+++ b/app/behandling-sok/components/KriteriumListe.tsx
@@ -1,0 +1,68 @@
+import { ActionMenu, Button, VStack } from '@navikt/ds-react'
+import type { KriterieGruppe, KriterieType, Kriterium, Valideringsfeil } from '../lib/kriterier'
+import { ALLE_KRITERIE_TYPER, KRITERIE_DEFINISJONER } from '../lib/kriterier'
+import type { BehandlingMetadata } from '../metadata-cache.server'
+import { KriteriumDispatcher } from './KriteriumDispatcher'
+
+type Props = {
+  kriterier: Kriterium[]
+  metadata: BehandlingMetadata | null
+  feil: Valideringsfeil[]
+  onChange: (nye: Kriterium[]) => void
+}
+
+const GRUPPE_REKKEFOLGE: KriterieGruppe[] = ['Tid', 'Behandling', 'Aktiviteter', 'Krav & sak']
+
+export function KriteriumListe({ kriterier, metadata, feil, onChange }: Props) {
+  function leggTil(type: KriterieType) {
+    const defaultVerdi = KRITERIE_DEFINISJONER[type].defaultVerdi()
+    onChange([...kriterier, defaultVerdi])
+  }
+
+  function endre(idx: number, k: Kriterium) {
+    onChange(kriterier.map((eks, i) => (i === idx ? k : eks)))
+  }
+
+  function fjern(idx: number) {
+    onChange(kriterier.filter((_, i) => i !== idx))
+  }
+
+  return (
+    <VStack gap="space-12">
+      {kriterier.map((k, idx) => (
+        <KriteriumDispatcher
+          key={`${k.type}-${idx}`}
+          kriterium={k}
+          indeks={idx}
+          metadata={metadata}
+          feilForKriterium={feil.filter((f) => f.kriterieIndeks === idx)}
+          onChange={(ny) => endre(idx, ny)}
+          onFjern={() => fjern(idx)}
+        />
+      ))}
+
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button variant="secondary" size="small">
+            + Legg til kriterium
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          {GRUPPE_REKKEFOLGE.map((gruppe) => {
+            const typerIGruppe = ALLE_KRITERIE_TYPER.filter((t) => KRITERIE_DEFINISJONER[t].gruppe === gruppe)
+            return (
+              <ActionMenu.Group key={gruppe} label={gruppe}>
+                {typerIGruppe.map((type) => (
+                  <ActionMenu.Item key={type} onSelect={() => leggTil(type)}>
+                    {KRITERIE_DEFINISJONER[type].visningsnavn}
+                    {KRITERIE_DEFINISJONER[type].tidsfilter ? ' ★' : ''}
+                  </ActionMenu.Item>
+                ))}
+              </ActionMenu.Group>
+            )
+          })}
+        </ActionMenu.Content>
+      </ActionMenu>
+    </VStack>
+  )
+}

--- a/app/behandling-sok/components/LimInnJsonModal.tsx
+++ b/app/behandling-sok/components/LimInnJsonModal.tsx
@@ -1,0 +1,69 @@
+import { Button, Modal, Textarea, VStack } from '@navikt/ds-react'
+import { useState } from 'react'
+import type { Kriterium } from '../lib/kriterier'
+import { erKjentKriterieType } from '../lib/kriterier'
+import type { Aggregering, Tidsdimensjon, Visning } from '../lib/url-state'
+
+export type Snapshot = {
+  schemaVersion?: string
+  behandlingType: string | null
+  visning?: Visning
+  aggregering?: Aggregering
+  tidsdimensjon?: Tidsdimensjon
+  kriterier: Kriterium[]
+}
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  onApply: (snapshot: Snapshot) => void
+}
+
+export function LimInnJsonModal({ open, onClose, onApply }: Props) {
+  const [text, setText] = useState('')
+  const [feil, setFeil] = useState<string | null>(null)
+
+  function håndterApply() {
+    try {
+      const parsed = JSON.parse(text)
+      if (typeof parsed !== 'object' || parsed === null) throw new Error('Forventet objekt')
+      const kriterier = Array.isArray(parsed.kriterier) ? parsed.kriterier : []
+      for (const k of kriterier) {
+        if (!k || typeof k !== 'object' || !('type' in k) || !erKjentKriterieType(String(k.type))) {
+          throw new Error(`Ukjent kriterium-type: ${JSON.stringify(k)}`)
+        }
+      }
+      onApply(parsed as Snapshot)
+      setText('')
+      setFeil(null)
+      onClose()
+    } catch (e) {
+      setFeil(e instanceof Error ? e.message : 'Ugyldig JSON')
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} header={{ heading: 'Lim inn JSON-søk' }} width={600}>
+      <Modal.Body>
+        <VStack gap="space-12">
+          <Textarea
+            label="Lim inn et tidligere kopiert JSON-søk"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            error={feil ?? undefined}
+            minRows={10}
+            resize
+          />
+        </VStack>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="primary" onClick={håndterApply}>
+          Bruk søk
+        </Button>
+        <Button variant="tertiary" onClick={onClose}>
+          Avbryt
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/app/behandling-sok/components/SensitiveVerdierBanner.tsx
+++ b/app/behandling-sok/components/SensitiveVerdierBanner.tsx
@@ -1,0 +1,10 @@
+import { Alert } from '@navikt/ds-react'
+
+export function SensitiveVerdierBanner() {
+  return (
+    <Alert variant="warning" size="small">
+      Søket inneholder sensitive verdier (NAV-identer eller behandlingsserie-UUID) som ikke lagres i URL. Bruk «Kopiér
+      som JSON» for å arkivere eller dele søket sikkert.
+    </Alert>
+  )
+}

--- a/app/behandling-sok/components/TreffTabell.tsx
+++ b/app/behandling-sok/components/TreffTabell.tsx
@@ -11,6 +11,7 @@ export type Treff = {
   sisteKjoring?: string | null
   utsattTil?: string | null
   prioritet?: number | null
+  kravId?: number | null
   opprettetAv?: string | null
 }
 

--- a/app/behandling-sok/components/TreffTabell.tsx
+++ b/app/behandling-sok/components/TreffTabell.tsx
@@ -1,0 +1,95 @@
+import { BodyShort, Button, Link, Table } from '@navikt/ds-react'
+
+export type Treff = {
+  behandlingId: number
+  behandlingType: string
+  status: string
+  ansvarligTeam?: string | null
+  opprettet: string
+  ferdig?: string | null
+  stoppet?: string | null
+  sisteKjoring?: string | null
+  utsattTil?: string | null
+  prioritet?: number | null
+  opprettetAv?: string | null
+}
+
+type Props = {
+  treff: Treff[]
+  totalAntallVist: number
+  nesteCursor: { opprettet: string; behandlingId: number } | null
+  isLoadingMore: boolean
+  /** True når committed-state har endret seg uten at brukeren har kjørt søket på nytt — disable paginering. */
+  paginringDisabledFordiUkjorteEndringer: boolean
+  onLastMer: () => void
+}
+
+export function TreffTabell({
+  treff,
+  totalAntallVist,
+  nesteCursor,
+  isLoadingMore,
+  paginringDisabledFordiUkjorteEndringer,
+  onLastMer,
+}: Props) {
+  if (treff.length === 0) {
+    return <BodyShort>Ingen treff for valgte kriterier.</BodyShort>
+  }
+  return (
+    <>
+      <Table size="small" zebraStripes>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Behandling-ID</Table.HeaderCell>
+            <Table.HeaderCell>Type</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+            <Table.HeaderCell>Ansvarlig team</Table.HeaderCell>
+            <Table.HeaderCell>Prioritet</Table.HeaderCell>
+            <Table.HeaderCell>Opprettet</Table.HeaderCell>
+            <Table.HeaderCell>Sist kjørt</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {treff.map((t) => (
+            <Table.Row key={t.behandlingId}>
+              <Table.DataCell>
+                <Link href={`/behandling/${t.behandlingId}`}>{t.behandlingId}</Link>
+              </Table.DataCell>
+              <Table.DataCell>{t.behandlingType}</Table.DataCell>
+              <Table.DataCell>{t.status}</Table.DataCell>
+              <Table.DataCell>{t.ansvarligTeam ?? '–'}</Table.DataCell>
+              <Table.DataCell>{t.prioritet ?? '–'}</Table.DataCell>
+              <Table.DataCell>{new Date(t.opprettet).toLocaleString('nb-NO')}</Table.DataCell>
+              <Table.DataCell>{t.sisteKjoring ? new Date(t.sisteKjoring).toLocaleString('nb-NO') : '–'}</Table.DataCell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      <div
+        style={{
+          marginTop: 'var(--ax-space-12)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <BodyShort size="small">
+          Viser {totalAntallVist.toLocaleString('nb-NO')}
+          {nesteCursor ? ' (flere tilgjengelig — last mer for å se)' : ''}
+        </BodyShort>
+        {nesteCursor && (
+          <Button
+            size="small"
+            variant="secondary"
+            loading={isLoadingMore}
+            disabled={paginringDisabledFordiUkjorteEndringer}
+            onClick={onLastMer}
+            title={paginringDisabledFordiUkjorteEndringer ? 'Kjør søket på nytt før du laster flere treff' : undefined}
+          >
+            Last mer
+          </Button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/app/behandling-sok/components/editors/CheckboxEditor.tsx
+++ b/app/behandling-sok/components/editors/CheckboxEditor.tsx
@@ -1,0 +1,9 @@
+import { BodyShort } from '@navikt/ds-react'
+
+/**
+ * For kriterier uten parametre — bare informasjon om at filteret er aktivt.
+ * (HAR_AAPEN_MANUELL_BEHANDLING, HAR_AAPEN_BREVBESTILLING, KONTROLLPUNKT_ER_KRITISK)
+ */
+export function CheckboxEditor({ beskrivelse }: { beskrivelse: string }) {
+  return <BodyShort size="small">{beskrivelse}</BodyShort>
+}

--- a/app/behandling-sok/components/editors/DatoInput.tsx
+++ b/app/behandling-sok/components/editors/DatoInput.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+type Props = {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  error?: string
+  description?: ReactNode
+  id?: string
+}
+
+/**
+ * Native <input type="date"> wrapped i Aksel-aktig label/error-styling.
+ * Brukes fordi Aksel TextField type ikke aksepterer "date".
+ */
+export function DatoInput({ label, value, onChange, error, description, id }: Props) {
+  const inputId = id ?? `dato-${Math.random().toString(36).slice(2, 8)}`
+  return (
+    <div className="navds-form-field navds-form-field--small" style={{ display: 'flex', flexDirection: 'column' }}>
+      <label htmlFor={inputId} className="navds-form-field__label navds-label navds-label--small">
+        {label}
+      </label>
+      {description && (
+        <div className="navds-form-field__description navds-body-short navds-body-short--small">{description}</div>
+      )}
+      <input
+        id={inputId}
+        type="date"
+        className="navds-text-field__input navds-body-short navds-body-short--small"
+        value={value}
+        aria-invalid={!!error}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ minHeight: 32, padding: '0 var(--ax-space-8)', borderRadius: 4 }}
+      />
+      {error && <div className="navds-form-field__error navds-error-message">{error}</div>}
+    </div>
+  )
+}

--- a/app/behandling-sok/components/editors/DatoInput.tsx
+++ b/app/behandling-sok/components/editors/DatoInput.tsx
@@ -1,38 +1,55 @@
+import { DatePicker, useDatepicker } from '@navikt/ds-react'
 import type { ReactNode } from 'react'
+import { useEffect, useRef } from 'react'
 
 type Props = {
   label: string
+  /** ISO `YYYY-MM-DD` eller tom streng for ingen verdi. */
   value: string
+  /** Ny ISO-streng (`YYYY-MM-DD`) eller tom streng når brukeren tømmer feltet. */
   onChange: (v: string) => void
   error?: string
   description?: ReactNode
   id?: string
 }
 
+function parseISO(value: string): Date | undefined {
+  if (!value) return undefined
+  const [y, m, d] = value.split('-').map(Number)
+  if (!y || !m || !d) return undefined
+  const date = new Date(y, m - 1, d)
+  if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) return undefined
+  return date
+}
+
+function toISO(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
 /**
- * Native <input type="date"> wrapped i Aksel-aktig label/error-styling.
- * Brukes fordi Aksel TextField type ikke aksepterer "date".
+ * Aksel DatePicker.Input wrapper som tar/gir ISO-streng (`YYYY-MM-DD`).
+ * Tomt felt → onChange('').
  */
 export function DatoInput({ label, value, onChange, error, description, id }: Props) {
-  const inputId = id ?? `dato-${Math.random().toString(36).slice(2, 8)}`
+  const initialDate = parseISO(value)
+  const { datepickerProps, inputProps, setSelected } = useDatepicker({
+    defaultSelected: initialDate,
+    onDateChange: (d) => onChange(d ? toISO(d) : ''),
+  })
+
+  // Hold input synkronisert hvis ekstern state endres (f.eks. preset-knapp eller "Lim inn JSON").
+  const setSelectedRef = useRef(setSelected)
+  setSelectedRef.current = setSelected
+  useEffect(() => {
+    setSelectedRef.current(parseISO(value))
+  }, [value])
+
   return (
-    <div className="navds-form-field navds-form-field--small" style={{ display: 'flex', flexDirection: 'column' }}>
-      <label htmlFor={inputId} className="navds-form-field__label navds-label navds-label--small">
-        {label}
-      </label>
-      {description && (
-        <div className="navds-form-field__description navds-body-short navds-body-short--small">{description}</div>
-      )}
-      <input
-        id={inputId}
-        type="date"
-        className="navds-text-field__input navds-body-short navds-body-short--small"
-        value={value}
-        aria-invalid={!!error}
-        onChange={(e) => onChange(e.target.value)}
-        style={{ minHeight: 32, padding: '0 var(--ax-space-8)', borderRadius: 4 }}
-      />
-      {error && <div className="navds-form-field__error navds-error-message">{error}</div>}
-    </div>
+    <DatePicker {...datepickerProps}>
+      <DatePicker.Input {...inputProps} id={id} label={label} description={description} size="small" error={error} />
+    </DatePicker>
   )
 }

--- a/app/behandling-sok/components/editors/MultiSelectEditor.tsx
+++ b/app/behandling-sok/components/editors/MultiSelectEditor.tsx
@@ -1,0 +1,38 @@
+import { UNSAFE_Combobox } from '@navikt/ds-react'
+
+type Props = {
+  label: string
+  alternativer: string[]
+  /** Verdier som finnes i `observed` men ikke `supported` — merkes "(historisk)". */
+  historiske?: string[]
+  valgte: string[]
+  onChange: (nye: string[]) => void
+  feil?: string
+}
+
+/**
+ * Generisk multi-select av strings, fôret fra metadata (status, team, sakstyper, etc.).
+ * Sammensetter `supported ∪ observed` og merker observed-only som "(historisk)".
+ */
+export function MultiSelectEditor({ label, alternativer, historiske = [], valgte, onChange, feil }: Props) {
+  const historiskeSet = new Set(historiske)
+  const alleAlternativer = Array.from(new Set([...alternativer, ...historiske])).sort()
+  const options = alleAlternativer.map((v) => ({
+    label: historiskeSet.has(v) ? `${v} (historisk)` : v,
+    value: v,
+  }))
+
+  return (
+    <UNSAFE_Combobox
+      label={label}
+      size="small"
+      options={options}
+      isMultiSelect
+      selectedOptions={valgte}
+      onToggleSelected={(option, isSelected) => {
+        onChange(isSelected ? [...valgte, option] : valgte.filter((v) => v !== option))
+      }}
+      error={feil}
+    />
+  )
+}

--- a/app/behandling-sok/components/editors/MultiSelectMedOperatorEditor.tsx
+++ b/app/behandling-sok/components/editors/MultiSelectMedOperatorEditor.tsx
@@ -1,0 +1,51 @@
+import { ToggleGroup } from '@navikt/ds-react'
+import type { Operator } from '../../lib/kriterier'
+import { MultiSelectEditor } from './MultiSelectEditor'
+
+type Props = {
+  label: string
+  alternativer: string[]
+  historiske?: string[]
+  valgte: string[]
+  operator: Operator
+  onChange: (nye: { valgte: string[]; operator: Operator }) => void
+  feil?: string
+}
+
+/**
+ * Multi-select med AND/OR-toggle for kriterier som må kunne uttrykke begge.
+ * OR = "minst én av", AND = "alle disse" (per spec).
+ */
+export function MultiSelectMedOperatorEditor({
+  label,
+  alternativer,
+  historiske,
+  valgte,
+  operator,
+  onChange,
+  feil,
+}: Props) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--ax-space-12)', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+      <div style={{ flex: 1, minWidth: 280 }}>
+        <MultiSelectEditor
+          label={label}
+          alternativer={alternativer}
+          historiske={historiske}
+          valgte={valgte}
+          onChange={(nye) => onChange({ valgte: nye, operator })}
+          feil={feil}
+        />
+      </div>
+      <ToggleGroup
+        size="small"
+        label="Kombinasjon"
+        value={operator}
+        onChange={(v) => onChange({ valgte, operator: v as Operator })}
+      >
+        <ToggleGroup.Item value="OR">Minst én</ToggleGroup.Item>
+        <ToggleGroup.Item value="AND">Alle</ToggleGroup.Item>
+      </ToggleGroup>
+    </div>
+  )
+}

--- a/app/behandling-sok/components/editors/MultiTallEditor.tsx
+++ b/app/behandling-sok/components/editors/MultiTallEditor.tsx
@@ -1,0 +1,72 @@
+import { Chips, TextField } from '@navikt/ds-react'
+import { useState } from 'react'
+
+type Props = {
+  label: string
+  prioriteter: number[]
+  onChange: (nye: number[]) => void
+  feil?: string
+  min?: number
+  max?: number
+}
+
+/**
+ * Chip-input for tall (HAR_PRIORITET). Aksepterer heltall i range.
+ */
+export function MultiTallEditor({ label, prioriteter, onChange, feil, min = 0, max = 100 }: Props) {
+  const [input, setInput] = useState('')
+  const [lokalFeil, setLokalFeil] = useState<string | null>(null)
+
+  function leggTil(s: string) {
+    const trimmed = s.trim()
+    if (!trimmed) return
+    const n = Number(trimmed)
+    if (!Number.isInteger(n) || n < min || n > max) {
+      setLokalFeil(`Verdi må være heltall mellom ${min} og ${max}`)
+      return
+    }
+    if (prioriteter.includes(n)) {
+      setLokalFeil(`${n} er allerede lagt til`)
+      return
+    }
+    onChange([...prioriteter, n])
+    setInput('')
+    setLokalFeil(null)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ax-space-8)' }}>
+      <TextField
+        label={label}
+        size="small"
+        description={`Trykk Enter eller komma for å legge til (${min}–${max})`}
+        value={input}
+        onChange={(e) => {
+          const v = e.target.value
+          if (v.endsWith(',')) {
+            leggTil(v.slice(0, -1))
+          } else {
+            setInput(v)
+            setLokalFeil(null)
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            leggTil(input)
+          }
+        }}
+        error={lokalFeil ?? feil}
+      />
+      {prioriteter.length > 0 && (
+        <Chips>
+          {prioriteter.map((p) => (
+            <Chips.Removable key={p} onClick={() => onChange(prioriteter.filter((x) => x !== p))}>
+              {String(p)}
+            </Chips.Removable>
+          ))}
+        </Chips>
+      )}
+    </div>
+  )
+}

--- a/app/behandling-sok/components/editors/PeriodeEditor.tsx
+++ b/app/behandling-sok/components/editors/PeriodeEditor.tsx
@@ -1,0 +1,30 @@
+import type { Kriterium } from '../../lib/kriterier'
+import { DatoInput } from './DatoInput'
+
+type Props = {
+  kriterium: Extract<
+    Kriterium,
+    { type: 'OPPRETTET_I_PERIODE' | 'FULLFORT_I_PERIODE' | 'STOPPET_I_PERIODE' | 'SIST_KJORT_I_PERIODE' }
+  >
+  onChange: (k: Props['kriterium']) => void
+  feil?: { fom?: string; tom?: string }
+}
+
+export function PeriodeEditor({ kriterium, onChange, feil }: Props) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--ax-space-12)' }}>
+      <DatoInput
+        label="Fra og med"
+        value={kriterium.fom}
+        onChange={(v) => onChange({ ...kriterium, fom: v })}
+        error={feil?.fom}
+      />
+      <DatoInput
+        label="Til og med"
+        value={kriterium.tom}
+        onChange={(v) => onChange({ ...kriterium, tom: v })}
+        error={feil?.tom}
+      />
+    </div>
+  )
+}

--- a/app/behandling-sok/components/editors/TagInputEditor.tsx
+++ b/app/behandling-sok/components/editors/TagInputEditor.tsx
@@ -1,0 +1,71 @@
+import { Chips, TextField } from '@navikt/ds-react'
+import { useState } from 'react'
+import { NAV_IDENT_REGEX } from '../../lib/kriterier'
+
+type Props = {
+  label: string
+  identer: string[]
+  onChange: (nye: string[]) => void
+  feil?: string
+}
+
+/**
+ * Chip-input for NAV-identer — én ident per chip. Trykk Enter eller komma for å legge til.
+ * Validerer regex per ident og avviser ugyldige (uten å miste tekst-input).
+ */
+export function TagInputEditor({ label, identer, onChange, feil }: Props) {
+  const [input, setInput] = useState('')
+  const [lokalFeil, setLokalFeil] = useState<string | null>(null)
+
+  function leggTil(ident: string) {
+    const trimmed = ident.trim()
+    if (!trimmed) return
+    if (!NAV_IDENT_REGEX.test(trimmed)) {
+      setLokalFeil(`Ugyldig ident "${trimmed}" (kun A-Z, 0-9, _, ., maks 32 tegn)`)
+      return
+    }
+    if (identer.includes(trimmed)) {
+      setLokalFeil(`Ident "${trimmed}" er allerede lagt til`)
+      return
+    }
+    onChange([...identer, trimmed])
+    setInput('')
+    setLokalFeil(null)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ax-space-8)' }}>
+      <TextField
+        label={label}
+        size="small"
+        description="Trykk Enter eller skriv komma for å legge til. Maks 100."
+        value={input}
+        onChange={(e) => {
+          const v = e.target.value
+          if (v.endsWith(',')) {
+            leggTil(v.slice(0, -1))
+          } else {
+            setInput(v)
+            setLokalFeil(null)
+          }
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            leggTil(input)
+          }
+        }}
+        error={lokalFeil ?? feil}
+      />
+      {identer.length > 0 && (
+        <Chips>
+          {identer.map((ident) => (
+            <Chips.Removable key={ident} onClick={() => onChange(identer.filter((x) => x !== ident))}>
+              {ident}
+            </Chips.Removable>
+          ))}
+        </Chips>
+      )}
+    </div>
+  )
+}

--- a/app/behandling-sok/components/editors/TallEditor.tsx
+++ b/app/behandling-sok/components/editors/TallEditor.tsx
@@ -1,0 +1,27 @@
+import { TextField } from '@navikt/ds-react'
+
+type Props = {
+  label: string
+  verdi: number
+  onChange: (verdi: number) => void
+  feil?: string
+  min?: number
+}
+
+export function TallEditor({ label, verdi, onChange, feil, min = 0 }: Props) {
+  return (
+    <TextField
+      label={label}
+      type="number"
+      size="small"
+      value={String(verdi)}
+      min={min}
+      onChange={(e) => {
+        const n = Number(e.target.value)
+        onChange(Number.isFinite(n) ? n : 0)
+      }}
+      error={feil}
+      style={{ maxWidth: 160 }}
+    />
+  )
+}

--- a/app/behandling-sok/components/editors/ToggleEditor.tsx
+++ b/app/behandling-sok/components/editors/ToggleEditor.tsx
@@ -1,0 +1,16 @@
+import { ToggleGroup } from '@navikt/ds-react'
+
+type Props = {
+  label: string
+  verdi: boolean
+  onChange: (verdi: boolean) => void
+}
+
+export function ToggleEditor({ label, verdi, onChange }: Props) {
+  return (
+    <ToggleGroup size="small" label={label} value={verdi ? 'JA' : 'NEI'} onChange={(v) => onChange(v === 'JA')}>
+      <ToggleGroup.Item value="JA">Ja</ToggleGroup.Item>
+      <ToggleGroup.Item value="NEI">Nei</ToggleGroup.Item>
+    </ToggleGroup>
+  )
+}

--- a/app/behandling-sok/components/editors/UuidEditor.tsx
+++ b/app/behandling-sok/components/editors/UuidEditor.tsx
@@ -1,0 +1,22 @@
+import { TextField } from '@navikt/ds-react'
+
+type Props = {
+  label: string
+  uuid: string
+  onChange: (uuid: string) => void
+  feil?: string
+}
+
+export function UuidEditor({ label, uuid, onChange, feil }: Props) {
+  return (
+    <TextField
+      label={label}
+      size="small"
+      description="Format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      value={uuid}
+      onChange={(e) => onChange(e.target.value)}
+      error={feil}
+      style={{ maxWidth: 360 }}
+    />
+  )
+}

--- a/app/behandling-sok/components/editors/ValgfriDatoEditor.tsx
+++ b/app/behandling-sok/components/editors/ValgfriDatoEditor.tsx
@@ -1,0 +1,20 @@
+import { DatoInput } from './DatoInput'
+
+type Props = {
+  label: string
+  verdi: string | null | undefined
+  onChange: (verdi: string | null) => void
+  feil?: string
+}
+
+export function ValgfriDatoEditor({ label, verdi, onChange, feil }: Props) {
+  return (
+    <DatoInput
+      label={label}
+      description="Valgfritt — la stå tom for å ikke filtrere på dato"
+      value={verdi ?? ''}
+      onChange={(v) => onChange(v === '' ? null : v)}
+      error={feil}
+    />
+  )
+}

--- a/app/behandling-sok/lib/formatters.test.ts
+++ b/app/behandling-sok/lib/formatters.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formaterBucketLabel, tidsdimensjonLabel } from './formatters'
+
+describe('formaterBucketLabel', () => {
+  it('formaterer DAG', () => {
+    expect(formaterBucketLabel('2026-03-15T00:00:00', 'DAG')).toBe('15. mar 2026')
+  })
+  it('formaterer MAANED', () => {
+    expect(formaterBucketLabel('2026-03-01T00:00:00', 'MAANED')).toBe('mar 2026')
+  })
+  it('formaterer KVARTAL', () => {
+    expect(formaterBucketLabel('2026-04-01T00:00:00', 'KVARTAL')).toBe('Q2 2026')
+    expect(formaterBucketLabel('2026-01-01T00:00:00', 'KVARTAL')).toBe('Q1 2026')
+    expect(formaterBucketLabel('2026-12-01T00:00:00', 'KVARTAL')).toBe('Q4 2026')
+  })
+  it('formaterer AAR', () => {
+    expect(formaterBucketLabel('2026-01-01T00:00:00', 'AAR')).toBe('2026')
+  })
+  it('returnerer rå streng for ugyldig input', () => {
+    expect(formaterBucketLabel('ikke-en-dato', 'MAANED')).toBe('ikke-en-dato')
+  })
+})
+
+describe('tidsdimensjonLabel', () => {
+  it('mapper kjente verdier', () => {
+    expect(tidsdimensjonLabel('OPPRETTET')).toBe('opprettet')
+    expect(tidsdimensjonLabel('SISTE_KJORING')).toBe('sist kjørt')
+  })
+})

--- a/app/behandling-sok/lib/formatters.ts
+++ b/app/behandling-sok/lib/formatters.ts
@@ -1,0 +1,46 @@
+import type { Aggregering } from './url-state'
+
+const NB_MND = ['jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des']
+
+/**
+ * Formaterer et bucket-startpunkt (ISO-dato/tid) etter hvilken aggregering som er valgt.
+ * Returnerer en kort, lesbar etikett for graf-x-aksen og tabellvisning.
+ */
+export function formaterBucketLabel(periodeStartIso: string, aggregering: Aggregering): string {
+  // Godta både YYYY-MM-DD og YYYY-MM-DDTHH:mm:ss
+  const datoDel = periodeStartIso.slice(0, 10)
+  const [aar, mnd, dag] = datoDel.split('-').map(Number)
+  if (!aar || !mnd || !dag) return periodeStartIso
+
+  switch (aggregering) {
+    case 'DAG':
+      return `${dag}. ${NB_MND[mnd - 1]} ${aar}`
+    case 'UKE':
+      return `${dag}. ${NB_MND[mnd - 1]} ${aar} (uke)`
+    case 'MAANED':
+      return `${NB_MND[mnd - 1]} ${aar}`
+    case 'KVARTAL': {
+      const kv = Math.floor((mnd - 1) / 3) + 1
+      return `Q${kv} ${aar}`
+    }
+    case 'AAR':
+      return String(aar)
+    default:
+      return periodeStartIso
+  }
+}
+
+export function tidsdimensjonLabel(td: string): string {
+  switch (td) {
+    case 'OPPRETTET':
+      return 'opprettet'
+    case 'FULLFORT':
+      return 'fullført'
+    case 'STOPPET':
+      return 'stoppet'
+    case 'SISTE_KJORING':
+      return 'sist kjørt'
+    default:
+      return td
+  }
+}

--- a/app/behandling-sok/lib/kriterier.test.ts
+++ b/app/behandling-sok/lib/kriterier.test.ts
@@ -42,7 +42,7 @@ describe('maanederMellom', () => {
 
 describe('KRITERIE_DEFINISJONER', () => {
   it('har en entry per KriterieType', () => {
-    expect(ALLE_KRITERIE_TYPER.length).toBe(21)
+    expect(ALLE_KRITERIE_TYPER.length).toBe(22)
     for (const type of ALLE_KRITERIE_TYPER) {
       expect(KRITERIE_DEFINISJONER[type]).toBeDefined()
       expect(KRITERIE_DEFINISJONER[type].type).toBe(type)

--- a/app/behandling-sok/lib/kriterier.test.ts
+++ b/app/behandling-sok/lib/kriterier.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALLE_KRITERIE_TYPER,
+  erKjentKriterieType,
+  harTidsfilter,
+  isSensitiv,
+  KRITERIE_DEFINISJONER,
+  type Kriterium,
+  maanederMellom,
+  parseStrictIsoDate,
+  validerKriterier,
+} from './kriterier'
+
+describe('parseStrictIsoDate', () => {
+  it('aksepterer gyldige datoer', () => {
+    expect(parseStrictIsoDate('2025-01-15')).not.toBeNull()
+    expect(parseStrictIsoDate('2024-02-29')).not.toBeNull() // skuddår
+  })
+  it('avviser ugyldig format', () => {
+    expect(parseStrictIsoDate('2025-1-15')).toBeNull()
+    expect(parseStrictIsoDate('2025/01/15')).toBeNull()
+    expect(parseStrictIsoDate('')).toBeNull()
+  })
+  it('avviser ikke-eksisterende datoer (ingen silent normalisering)', () => {
+    expect(parseStrictIsoDate('2026-02-31')).toBeNull()
+    expect(parseStrictIsoDate('2025-13-01')).toBeNull()
+    expect(parseStrictIsoDate('2025-02-29')).toBeNull() // ikke skuddår
+  })
+})
+
+describe('maanederMellom', () => {
+  it('regner riktig for fulle måneder', () => {
+    expect(maanederMellom(new Date(2025, 0, 1), new Date(2025, 11, 31))).toBe(11)
+    expect(maanederMellom(new Date(2024, 0, 1), new Date(2025, 11, 31))).toBe(23)
+  })
+  it('respekterer dag-i-måned', () => {
+    // 1. jan til 15. feb = 1 mnd og 14 dager → 1 mnd komplett
+    expect(maanederMellom(new Date(2025, 0, 15), new Date(2025, 1, 14))).toBe(0)
+    expect(maanederMellom(new Date(2025, 0, 15), new Date(2025, 1, 15))).toBe(1)
+  })
+})
+
+describe('KRITERIE_DEFINISJONER', () => {
+  it('har en entry per KriterieType', () => {
+    expect(ALLE_KRITERIE_TYPER.length).toBe(21)
+    for (const type of ALLE_KRITERIE_TYPER) {
+      expect(KRITERIE_DEFINISJONER[type]).toBeDefined()
+      expect(KRITERIE_DEFINISJONER[type].type).toBe(type)
+    }
+  })
+  it('default-verdi matcher type', () => {
+    for (const type of ALLE_KRITERIE_TYPER) {
+      const k = KRITERIE_DEFINISJONER[type].defaultVerdi()
+      expect(k.type).toBe(type)
+    }
+  })
+  it('har minst ett tidsfilter', () => {
+    const tidsfiltre = ALLE_KRITERIE_TYPER.filter((t) => KRITERIE_DEFINISJONER[t].tidsfilter)
+    expect(tidsfiltre.length).toBe(4)
+  })
+  it('OPPRETTET_AV og TILHORER_BEHANDLINGSSERIE er sensitive', () => {
+    expect(isSensitiv({ type: 'OPPRETTET_AV', identer: ['Z990123'] })).toBe(true)
+    expect(isSensitiv({ type: 'TILHORER_BEHANDLINGSSERIE', uuid: '00000000-0000-0000-0000-000000000000' })).toBe(true)
+    expect(isSensitiv({ type: 'HAR_STATUS', statuser: ['MAN'] })).toBe(false)
+  })
+})
+
+describe('erKjentKriterieType', () => {
+  it('aksepterer alle kjente typer', () => {
+    for (const t of ALLE_KRITERIE_TYPER) {
+      expect(erKjentKriterieType(t)).toBe(true)
+    }
+  })
+  it('avviser ukjent', () => {
+    expect(erKjentKriterieType('FOO_BAR')).toBe(false)
+    expect(erKjentKriterieType('')).toBe(false)
+  })
+})
+
+describe('harTidsfilter', () => {
+  it('false når ingen periode-kriterier', () => {
+    expect(harTidsfilter([{ type: 'HAR_STATUS', statuser: ['MAN'] }])).toBe(false)
+  })
+  it('true når et tidsfilter er med', () => {
+    expect(harTidsfilter([{ type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' }])).toBe(true)
+  })
+})
+
+describe('validerKriterier', () => {
+  it('manglerTidsfilter når ingen tidskriterium', () => {
+    const r = validerKriterier([{ type: 'HAR_STATUS', statuser: ['MAN'] }])
+    expect(r.manglerTidsfilter).toBe(true)
+    expect(r.feil).toEqual([])
+  })
+  it('aksepterer fullstendig periode', () => {
+    const r = validerKriterier([{ type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' }])
+    expect(r.manglerTidsfilter).toBe(false)
+    expect(r.feil).toEqual([])
+  })
+  it('aksepterer single-day periode', () => {
+    const r = validerKriterier([{ type: 'OPPRETTET_I_PERIODE', fom: '2025-06-15', tom: '2025-06-15' }])
+    expect(r.feil).toEqual([])
+  })
+  it('avviser tom > 24 mnd', () => {
+    const r = validerKriterier([{ type: 'OPPRETTET_I_PERIODE', fom: '2023-01-01', tom: '2025-06-01' }])
+    expect(r.feil.some((f) => f.melding.includes('24 måneder'))).toBe(true)
+  })
+  it('avviser fom > tom', () => {
+    const r = validerKriterier([{ type: 'OPPRETTET_I_PERIODE', fom: '2025-12-01', tom: '2025-01-01' }])
+    expect(r.feil.some((f) => f.melding.includes('etter fra-dato'))).toBe(true)
+  })
+  it('avviser ugyldig dato', () => {
+    const r = validerKriterier([{ type: 'OPPRETTET_I_PERIODE', fom: '2026-02-31', tom: '2026-12-31' }])
+    expect(r.feil.some((f) => f.felt === 'fom')).toBe(true)
+  })
+  it('avviser tom OPPRETTET_AV', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'OPPRETTET_AV', identer: [] },
+    ])
+    expect(r.feil.some((f) => f.melding.includes('Minst én ident'))).toBe(true)
+  })
+  it('avviser ugyldig NAV-ident', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'OPPRETTET_AV', identer: ['ugyldig ident med mellomrom'] },
+    ])
+    expect(r.feil.some((f) => f.melding.includes('Ugyldig ident'))).toBe(true)
+  })
+  it('avviser ugyldig UUID', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'TILHORER_BEHANDLINGSSERIE', uuid: 'ikke-en-uuid' },
+    ])
+    expect(r.feil.some((f) => f.felt === 'uuid')).toBe(true)
+  })
+  it('aksepterer gyldig UUID', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'TILHORER_BEHANDLINGSSERIE', uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+    ])
+    expect(r.feil).toEqual([])
+  })
+  it('avviser tom HAR_AKTIVITET_AV_TYPE', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'HAR_AKTIVITET_AV_TYPE', aktivitetTyper: [], operator: 'OR' },
+    ])
+    expect(r.feil.some((f) => f.felt === 'aktivitetTyper')).toBe(true)
+  })
+  it('avviser negativ terskel', () => {
+    const r = validerKriterier([
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'AKTIVITET_KJORT_FLERE_GANGER_ENN', terskel: -1 },
+    ])
+    expect(r.feil.some((f) => f.felt === 'terskel')).toBe(true)
+  })
+  it('valider hver periode for seg (rubber-duck-funn)', () => {
+    const k: Kriterium[] = [
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-06-30' },
+      { type: 'FULLFORT_I_PERIODE', fom: '2023-01-01', tom: '2025-06-01' }, // > 24 mnd
+    ]
+    const r = validerKriterier(k)
+    // Bare den ene perioden er for lang
+    expect(r.feil.filter((f) => f.melding.includes('24 måneder')).length).toBe(1)
+    expect(r.feil[0].kriterieIndeks).toBe(1)
+  })
+})

--- a/app/behandling-sok/lib/kriterier.ts
+++ b/app/behandling-sok/lib/kriterier.ts
@@ -26,6 +26,7 @@ export type Kriterium =
   | { type: 'HAR_FEILET_KJORING'; siden?: string | null }
   | { type: 'KRAVHODE_HAR_STATUS'; statuser: string[] }
   | { type: 'KRAVHODE_HAR_KONTROLLPUNKT'; kontrollpunktTyper: string[]; operator: Operator }
+  | { type: 'KRAVHODE_HAR_BEHANDLINGTYPE'; behandlingTyper: string[] }
   | { type: 'KONTROLLPUNKT_ER_KRITISK' }
   | { type: 'KRAV_GJELDER'; koder: string[] }
   | { type: 'SAK_HAR_TYPE'; sakstyper: string[] }
@@ -61,6 +62,7 @@ export type MetadataNokkel =
   | 'ansvarligeTeam'
   | 'aktivitetTyper'
   | 'kontrollpunktTyper'
+  | 'kravhodeBehandlingTyper'
   | 'none'
 
 export type KriterieDefinisjon = {
@@ -260,6 +262,17 @@ export const KRITERIE_DEFINISJONER: Record<KriterieType, KriterieDefinisjon> = {
     sensitiv: false,
     tidsfilter: false,
     defaultVerdi: () => ({ type: 'KRAVHODE_HAR_KONTROLLPUNKT', kontrollpunktTyper: [], operator: 'OR' }),
+  },
+  KRAVHODE_HAR_BEHANDLINGTYPE: {
+    type: 'KRAVHODE_HAR_BEHANDLINGTYPE',
+    visningsnavn: 'Kravhode har behandlingstype',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'kravhodeBehandlingTyper',
+    verdiNokkel: 'behandlingTyper' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KRAVHODE_HAR_BEHANDLINGTYPE', behandlingTyper: [] }),
   },
   KONTROLLPUNKT_ER_KRITISK: {
     type: 'KONTROLLPUNKT_ER_KRITISK',

--- a/app/behandling-sok/lib/kriterier.ts
+++ b/app/behandling-sok/lib/kriterier.ts
@@ -1,0 +1,414 @@
+/**
+ * DSL-typer + dispatcher-map for generisk behandlingssøk.
+ *
+ * Speiler `/api/behandling/sok`-kontrakten i pensjon-pen. Feltnavn er valgt etter spec-eksempelet
+ * (`aktivitetTyper`, `kontrollpunktTyper`, `statuser`); øvrige er kvalifiserte gjetninger basert
+ * på spec-tabellen og kan måtte justeres mot backend ved første test.
+ */
+
+export type Operator = 'AND' | 'OR'
+
+export type Kriterium =
+  | { type: 'OPPRETTET_I_PERIODE'; fom: string; tom: string }
+  | { type: 'FULLFORT_I_PERIODE'; fom: string; tom: string }
+  | { type: 'STOPPET_I_PERIODE'; fom: string; tom: string }
+  | { type: 'SIST_KJORT_I_PERIODE'; fom: string; tom: string }
+  | { type: 'HAR_STATUS'; statuser: string[] }
+  | { type: 'HAR_PRIORITET'; prioriteter: number[] }
+  | { type: 'HAR_ANSVARLIG_TEAM'; team: string[] }
+  | { type: 'OPPRETTET_AV'; identer: string[] }
+  | { type: 'ER_BATCH'; verdi: boolean }
+  | { type: 'TILHORER_BEHANDLINGSSERIE'; uuid: string }
+  | { type: 'HAR_AKTIVITET_AV_TYPE'; aktivitetTyper: string[]; operator: Operator }
+  | { type: 'AKTIVITET_KJORT_FLERE_GANGER_ENN'; terskel: number }
+  | { type: 'HAR_AAPEN_MANUELL_BEHANDLING' }
+  | { type: 'HAR_AAPEN_BREVBESTILLING' }
+  | { type: 'HAR_FEILET_KJORING'; siden?: string | null }
+  | { type: 'KRAVHODE_HAR_STATUS'; statuser: string[] }
+  | { type: 'KRAVHODE_HAR_KONTROLLPUNKT'; kontrollpunktTyper: string[]; operator: Operator }
+  | { type: 'KONTROLLPUNKT_ER_KRITISK' }
+  | { type: 'KRAV_GJELDER'; koder: string[] }
+  | { type: 'SAK_HAR_TYPE'; sakstyper: string[] }
+  | { type: 'KRAV_HAR_EIERENHET'; eierenheter: string[] }
+
+export type KriterieType = Kriterium['type']
+
+export type KriterieGruppe = 'Tid' | 'Behandling' | 'Aktiviteter' | 'Krav & sak'
+
+/** Editor-primitives — hver dekker én eller flere kriterietyper. */
+export type EditorKomponent =
+  | 'PeriodeEditor'
+  | 'MultiSelectEditor'
+  | 'MultiSelectMedOperatorEditor'
+  | 'CheckboxEditor'
+  | 'ToggleEditor'
+  | 'TallEditor'
+  | 'TagInputEditor'
+  | 'UuidEditor'
+  | 'ValgfriDatoEditor'
+  | 'MultiTallEditor'
+
+/**
+ * Hvilken metadata-nøkkel skal MultiSelectEditor lese fra for å fylle dropdown.
+ * `none` = editoren bruker ikke metadata.
+ */
+export type MetadataNokkel =
+  | 'behandlingStatuser'
+  | 'kravStatuser'
+  | 'kravGjelderKoder'
+  | 'sakstyper'
+  | 'eierenheter'
+  | 'ansvarligeTeam'
+  | 'aktivitetTyper'
+  | 'kontrollpunktTyper'
+  | 'none'
+
+export type KriterieDefinisjon = {
+  type: KriterieType
+  visningsnavn: string
+  gruppe: KriterieGruppe
+  editor: EditorKomponent
+  /** Hvilken metadata-feltnavn dekoder/popuerer dropdown. */
+  metadataNokkel: MetadataNokkel
+  /** Felt-nøkkelen i Kriterium-objektet for den valgte verdien (multi/single). */
+  verdiNokkel?: keyof Kriterium
+  /**
+   * Sensitive kriterier holdes utenfor URL og lagres i sessionStorage istedenfor.
+   * NAV-identer og UUID kan røpe at en bestemt person/behandlingsserie eksisterer.
+   */
+  sensitiv: boolean
+  /** Default-verdi når brukeren legger til kriteriet. */
+  defaultVerdi: () => Kriterium
+  /** Et tids-kriterium (★) — minst ett kreves. */
+  tidsfilter: boolean
+}
+
+const i = (verdi: string): string => verdi // identity helper for readability
+
+export const KRITERIE_DEFINISJONER: Record<KriterieType, KriterieDefinisjon> = {
+  OPPRETTET_I_PERIODE: {
+    type: 'OPPRETTET_I_PERIODE',
+    visningsnavn: 'Opprettet i periode',
+    gruppe: 'Tid',
+    editor: 'PeriodeEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: true,
+    defaultVerdi: () => ({ type: 'OPPRETTET_I_PERIODE', fom: '', tom: '' }),
+  },
+  FULLFORT_I_PERIODE: {
+    type: 'FULLFORT_I_PERIODE',
+    visningsnavn: 'Fullført i periode',
+    gruppe: 'Tid',
+    editor: 'PeriodeEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: true,
+    defaultVerdi: () => ({ type: 'FULLFORT_I_PERIODE', fom: '', tom: '' }),
+  },
+  STOPPET_I_PERIODE: {
+    type: 'STOPPET_I_PERIODE',
+    visningsnavn: 'Stoppet i periode',
+    gruppe: 'Tid',
+    editor: 'PeriodeEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: true,
+    defaultVerdi: () => ({ type: 'STOPPET_I_PERIODE', fom: '', tom: '' }),
+  },
+  SIST_KJORT_I_PERIODE: {
+    type: 'SIST_KJORT_I_PERIODE',
+    visningsnavn: 'Sist kjørt i periode',
+    gruppe: 'Tid',
+    editor: 'PeriodeEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: true,
+    defaultVerdi: () => ({ type: 'SIST_KJORT_I_PERIODE', fom: '', tom: '' }),
+  },
+  HAR_STATUS: {
+    type: 'HAR_STATUS',
+    visningsnavn: 'Har behandlingsstatus',
+    gruppe: 'Behandling',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'behandlingStatuser',
+    verdiNokkel: 'statuser' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_STATUS', statuser: [] }),
+  },
+  HAR_PRIORITET: {
+    type: 'HAR_PRIORITET',
+    visningsnavn: 'Har prioritet',
+    gruppe: 'Behandling',
+    editor: 'MultiTallEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_PRIORITET', prioriteter: [] }),
+  },
+  HAR_ANSVARLIG_TEAM: {
+    type: 'HAR_ANSVARLIG_TEAM',
+    visningsnavn: 'Har ansvarlig team',
+    gruppe: 'Behandling',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'ansvarligeTeam',
+    verdiNokkel: 'team' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_ANSVARLIG_TEAM', team: [] }),
+  },
+  OPPRETTET_AV: {
+    type: 'OPPRETTET_AV',
+    visningsnavn: 'Opprettet av',
+    gruppe: 'Behandling',
+    editor: 'TagInputEditor',
+    metadataNokkel: 'none',
+    sensitiv: true,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'OPPRETTET_AV', identer: [] }),
+  },
+  ER_BATCH: {
+    type: 'ER_BATCH',
+    visningsnavn: 'Er batch-behandling',
+    gruppe: 'Behandling',
+    editor: 'ToggleEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'ER_BATCH', verdi: true }),
+  },
+  TILHORER_BEHANDLINGSSERIE: {
+    type: 'TILHORER_BEHANDLINGSSERIE',
+    visningsnavn: 'Tilhører behandlingsserie',
+    gruppe: 'Behandling',
+    editor: 'UuidEditor',
+    metadataNokkel: 'none',
+    sensitiv: true,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'TILHORER_BEHANDLINGSSERIE', uuid: '' }),
+  },
+  HAR_AKTIVITET_AV_TYPE: {
+    type: 'HAR_AKTIVITET_AV_TYPE',
+    visningsnavn: 'Har aktivitet av type',
+    gruppe: 'Aktiviteter',
+    editor: 'MultiSelectMedOperatorEditor',
+    metadataNokkel: 'aktivitetTyper',
+    verdiNokkel: 'aktivitetTyper' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_AKTIVITET_AV_TYPE', aktivitetTyper: [], operator: 'OR' }),
+  },
+  AKTIVITET_KJORT_FLERE_GANGER_ENN: {
+    type: 'AKTIVITET_KJORT_FLERE_GANGER_ENN',
+    visningsnavn: 'Aktivitet kjørt flere ganger enn',
+    gruppe: 'Aktiviteter',
+    editor: 'TallEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'AKTIVITET_KJORT_FLERE_GANGER_ENN', terskel: 1 }),
+  },
+  HAR_AAPEN_MANUELL_BEHANDLING: {
+    type: 'HAR_AAPEN_MANUELL_BEHANDLING',
+    visningsnavn: 'Har åpen manuell behandling',
+    gruppe: 'Aktiviteter',
+    editor: 'CheckboxEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_AAPEN_MANUELL_BEHANDLING' }),
+  },
+  HAR_AAPEN_BREVBESTILLING: {
+    type: 'HAR_AAPEN_BREVBESTILLING',
+    visningsnavn: 'Har åpen brevbestilling',
+    gruppe: 'Aktiviteter',
+    editor: 'CheckboxEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_AAPEN_BREVBESTILLING' }),
+  },
+  HAR_FEILET_KJORING: {
+    type: 'HAR_FEILET_KJORING',
+    visningsnavn: 'Har feilet kjøring',
+    gruppe: 'Behandling',
+    editor: 'ValgfriDatoEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'HAR_FEILET_KJORING', siden: null }),
+  },
+  KRAVHODE_HAR_STATUS: {
+    type: 'KRAVHODE_HAR_STATUS',
+    visningsnavn: 'Kravhode har status',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'kravStatuser',
+    verdiNokkel: 'statuser' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KRAVHODE_HAR_STATUS', statuser: [] }),
+  },
+  KRAVHODE_HAR_KONTROLLPUNKT: {
+    type: 'KRAVHODE_HAR_KONTROLLPUNKT',
+    visningsnavn: 'Kravhode har kontrollpunkt',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectMedOperatorEditor',
+    metadataNokkel: 'kontrollpunktTyper',
+    verdiNokkel: 'kontrollpunktTyper' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KRAVHODE_HAR_KONTROLLPUNKT', kontrollpunktTyper: [], operator: 'OR' }),
+  },
+  KONTROLLPUNKT_ER_KRITISK: {
+    type: 'KONTROLLPUNKT_ER_KRITISK',
+    visningsnavn: 'Kontrollpunkt er kritisk',
+    gruppe: 'Krav & sak',
+    editor: 'CheckboxEditor',
+    metadataNokkel: 'none',
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KONTROLLPUNKT_ER_KRITISK' }),
+  },
+  KRAV_GJELDER: {
+    type: 'KRAV_GJELDER',
+    visningsnavn: 'Krav gjelder',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'kravGjelderKoder',
+    verdiNokkel: 'koder' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KRAV_GJELDER', koder: [] }),
+  },
+  SAK_HAR_TYPE: {
+    type: 'SAK_HAR_TYPE',
+    visningsnavn: 'Sak har type',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'sakstyper',
+    verdiNokkel: 'sakstyper' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'SAK_HAR_TYPE', sakstyper: [] }),
+  },
+  KRAV_HAR_EIERENHET: {
+    type: 'KRAV_HAR_EIERENHET',
+    visningsnavn: 'Krav har eierenhet',
+    gruppe: 'Krav & sak',
+    editor: 'MultiSelectEditor',
+    metadataNokkel: 'eierenheter',
+    verdiNokkel: 'eierenheter' as keyof Kriterium,
+    sensitiv: false,
+    tidsfilter: false,
+    defaultVerdi: () => ({ type: 'KRAV_HAR_EIERENHET', eierenheter: [] }),
+  },
+}
+
+export const ALLE_KRITERIE_TYPER: KriterieType[] = Object.keys(KRITERIE_DEFINISJONER) as KriterieType[]
+
+export function erKjentKriterieType(s: string): s is KriterieType {
+  return s in KRITERIE_DEFINISJONER
+}
+
+export function isSensitiv(k: Kriterium): boolean {
+  return KRITERIE_DEFINISJONER[k.type].sensitiv
+}
+
+export function harTidsfilter(kriterier: Kriterium[]): boolean {
+  return kriterier.some((k) => KRITERIE_DEFINISJONER[k.type].tidsfilter)
+}
+
+/* ──────────────────── Validering ──────────────────── */
+
+export const NAV_IDENT_REGEX = /^[A-Za-z0-9_.]{1,32}$/
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+export const ISO_DATO_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+export type Valideringsfeil = {
+  /** Indeks i kriterier-array. */
+  kriterieIndeks: number
+  /** Felt i kriteriet (for fokusering). */
+  felt?: string
+  melding: string
+}
+
+export type ValideringsResultat = {
+  feil: Valideringsfeil[]
+  manglerTidsfilter: boolean
+}
+
+export function parseStrictIsoDate(s: string): Date | null {
+  if (!ISO_DATO_REGEX.test(s)) return null
+  const [y, m, d] = s.split('-').map(Number)
+  if (!y || !m || !d) return null
+  const date = new Date(y, m - 1, d)
+  if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) return null
+  return date
+}
+
+export function maanederMellom(fom: Date, tom: Date): number {
+  const aar = tom.getFullYear() - fom.getFullYear()
+  const mnd = tom.getMonth() - fom.getMonth()
+  const dag = tom.getDate() < fom.getDate() ? -1 : 0
+  return aar * 12 + mnd + dag
+}
+
+export function validerKriterier(kriterier: Kriterium[]): ValideringsResultat {
+  const feil: Valideringsfeil[] = []
+  const manglerTidsfilter = !harTidsfilter(kriterier)
+
+  kriterier.forEach((k, idx) => {
+    const definisjon = KRITERIE_DEFINISJONER[k.type]
+    if (definisjon.tidsfilter && 'fom' in k && 'tom' in k) {
+      const fomD = parseStrictIsoDate(k.fom)
+      const tomD = parseStrictIsoDate(k.tom)
+      if (!fomD) feil.push({ kriterieIndeks: idx, felt: 'fom', melding: 'Fra-dato mangler eller er ugyldig' })
+      if (!tomD) feil.push({ kriterieIndeks: idx, felt: 'tom', melding: 'Til-dato mangler eller er ugyldig' })
+      if (fomD && tomD) {
+        if (fomD > tomD)
+          feil.push({ kriterieIndeks: idx, felt: 'tom', melding: 'Til-dato må være på eller etter fra-dato' })
+        else if (maanederMellom(fomD, tomD) > 24)
+          feil.push({ kriterieIndeks: idx, felt: 'tom', melding: 'Periode kan ikke være lengre enn 24 måneder' })
+      }
+    }
+
+    if (k.type === 'OPPRETTET_AV') {
+      if (k.identer.length === 0)
+        feil.push({ kriterieIndeks: idx, felt: 'identer', melding: 'Minst én ident må fylles inn' })
+      k.identer.forEach((ident) => {
+        if (!NAV_IDENT_REGEX.test(ident))
+          feil.push({ kriterieIndeks: idx, felt: 'identer', melding: `Ugyldig ident: ${i(ident)}` })
+      })
+    }
+
+    if (k.type === 'TILHORER_BEHANDLINGSSERIE' && !UUID_REGEX.test(k.uuid)) {
+      feil.push({
+        kriterieIndeks: idx,
+        felt: 'uuid',
+        melding: 'UUID må være på formatet xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+      })
+    }
+
+    if (k.type === 'HAR_FEILET_KJORING' && k.siden) {
+      if (!parseStrictIsoDate(k.siden)) {
+        feil.push({ kriterieIndeks: idx, felt: 'siden', melding: '«Siden»-dato må være gyldig' })
+      }
+    }
+
+    if (k.type === 'HAR_AKTIVITET_AV_TYPE' && k.aktivitetTyper.length === 0) {
+      feil.push({ kriterieIndeks: idx, felt: 'aktivitetTyper', melding: 'Velg minst én aktivitetstype' })
+    }
+
+    if (k.type === 'KRAVHODE_HAR_KONTROLLPUNKT' && k.kontrollpunktTyper.length === 0) {
+      feil.push({ kriterieIndeks: idx, felt: 'kontrollpunktTyper', melding: 'Velg minst ett kontrollpunkt' })
+    }
+
+    if (k.type === 'AKTIVITET_KJORT_FLERE_GANGER_ENN' && (!Number.isInteger(k.terskel) || k.terskel < 0)) {
+      feil.push({ kriterieIndeks: idx, felt: 'terskel', melding: 'Terskel må være et heltall ≥ 0' })
+    }
+  })
+
+  return { feil, manglerTidsfilter }
+}

--- a/app/behandling-sok/lib/request-builder.test.ts
+++ b/app/behandling-sok/lib/request-builder.test.ts
@@ -85,6 +85,10 @@ describe('rensKriterier mapper interne feltnavn til backend-DTO', () => {
     const r = rensKriterier([{ type: 'KRAV_HAR_EIERENHET', eierenheter: ['4849'] }])
     expect(r).toEqual([{ type: 'KRAV_HAR_EIERENHET', enhetsnr: ['4849'] }])
   })
+  it('HAR_ANSVARLIG_TEAM: team → teams', () => {
+    const r = rensKriterier([{ type: 'HAR_ANSVARLIG_TEAM', team: ['TEAM_ALDER'] }])
+    expect(r).toEqual([{ type: 'HAR_ANSVARLIG_TEAM', teams: ['TEAM_ALDER'] }])
+  })
   it('HAR_FEILET_KJORING: siden → sidenDato (utelater når null)', () => {
     expect(rensKriterier([{ type: 'HAR_FEILET_KJORING', siden: '2025-01-01' }])).toEqual([
       { type: 'HAR_FEILET_KJORING', sidenDato: '2025-01-01' },

--- a/app/behandling-sok/lib/request-builder.test.ts
+++ b/app/behandling-sok/lib/request-builder.test.ts
@@ -67,3 +67,33 @@ describe('buildAntallOverTidRequest', () => {
     expect(r.tidsdimensjon).toBe('OPPRETTET')
   })
 })
+
+describe('rensKriterier mapper interne feltnavn til backend-DTO', () => {
+  it('OPPRETTET_AV: identer → brukere', () => {
+    const r = rensKriterier([{ type: 'OPPRETTET_AV', identer: ['Z123', 'Z456'] }])
+    expect(r).toEqual([{ type: 'OPPRETTET_AV', brukere: ['Z123', 'Z456'] }])
+  })
+  it('TILHORER_BEHANDLINGSSERIE: uuid → behandlingSerieId', () => {
+    const r = rensKriterier([{ type: 'TILHORER_BEHANDLINGSSERIE', uuid: 'abc' }])
+    expect(r).toEqual([{ type: 'TILHORER_BEHANDLINGSSERIE', behandlingSerieId: 'abc' }])
+  })
+  it('ER_BATCH: verdi → erBatch', () => {
+    const r = rensKriterier([{ type: 'ER_BATCH', verdi: true }])
+    expect(r).toEqual([{ type: 'ER_BATCH', erBatch: true }])
+  })
+  it('KRAV_HAR_EIERENHET: eierenheter → enhetsnr', () => {
+    const r = rensKriterier([{ type: 'KRAV_HAR_EIERENHET', eierenheter: ['4849'] }])
+    expect(r).toEqual([{ type: 'KRAV_HAR_EIERENHET', enhetsnr: ['4849'] }])
+  })
+  it('HAR_FEILET_KJORING: siden → sidenDato (utelater når null)', () => {
+    expect(rensKriterier([{ type: 'HAR_FEILET_KJORING', siden: '2025-01-01' }])).toEqual([
+      { type: 'HAR_FEILET_KJORING', sidenDato: '2025-01-01' },
+    ])
+    expect(rensKriterier([{ type: 'HAR_FEILET_KJORING', siden: null }])).toEqual([{ type: 'HAR_FEILET_KJORING' }])
+  })
+  it('andre kriterier passerer uendret', () => {
+    expect(rensKriterier([{ type: 'HAR_STATUS', statuser: ['MAN'] }])).toEqual([
+      { type: 'HAR_STATUS', statuser: ['MAN'] },
+    ])
+  })
+})

--- a/app/behandling-sok/lib/request-builder.test.ts
+++ b/app/behandling-sok/lib/request-builder.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { Kriterium } from './kriterier'
+import { buildAntallOverTidRequest, buildTreffRequest, rensKriterier, SCHEMA_VERSION } from './request-builder'
+
+describe('rensKriterier', () => {
+  it('filtrerer bort tomme multi-select', () => {
+    const k: Kriterium[] = [
+      { type: 'HAR_STATUS', statuser: [] },
+      { type: 'HAR_STATUS', statuser: ['MAN'] },
+    ]
+    expect(rensKriterier(k)).toHaveLength(1)
+  })
+  it('beholder kriterier uten verdier (CheckboxEditor)', () => {
+    const k: Kriterium[] = [{ type: 'HAR_AAPEN_MANUELL_BEHANDLING' }, { type: 'KONTROLLPUNKT_ER_KRITISK' }]
+    expect(rensKriterier(k)).toHaveLength(2)
+  })
+  it('filtrerer bort tomme perioder', () => {
+    const k: Kriterium[] = [
+      { type: 'OPPRETTET_I_PERIODE', fom: '', tom: '' },
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+    ]
+    expect(rensKriterier(k)).toHaveLength(1)
+  })
+})
+
+describe('buildTreffRequest matcher spec-eksempel', () => {
+  it('reproduserer del-aut-utland-manuell-eksempelet', () => {
+    const r = buildTreffRequest(
+      'FleksibelApSak',
+      [
+        { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+        {
+          type: 'HAR_AKTIVITET_AV_TYPE',
+          aktivitetTyper: [
+            'FleksibelApSak_A412_VentPaaKompletteringAvGrunnlag',
+            'FleksibelApSak_A406_VurderSamboerAktivitet',
+          ],
+          operator: 'OR',
+        },
+        {
+          type: 'KRAVHODE_HAR_KONTROLLPUNKT',
+          kontrollpunktTyper: ['UTLAND', 'UTLAND_F_BH_MED_UTL'],
+          operator: 'OR',
+        },
+        { type: 'KRAVHODE_HAR_STATUS', statuser: ['MAN'] },
+      ],
+      null,
+      100,
+    )
+    expect(r.schemaVersion).toBe(SCHEMA_VERSION)
+    expect(r.behandlingType).toBe('FleksibelApSak')
+    expect(r.kriterier).toHaveLength(4)
+    expect(r.cursor).toBeNull()
+    expect(r.limit).toBe(100)
+  })
+})
+
+describe('buildAntallOverTidRequest', () => {
+  it('inkluderer aggregering og tidsdimensjon', () => {
+    const r = buildAntallOverTidRequest(
+      'FleksibelApSak',
+      [{ type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' }],
+      'MAANED',
+      'OPPRETTET',
+    )
+    expect(r.aggregering).toBe('MAANED')
+    expect(r.tidsdimensjon).toBe('OPPRETTET')
+  })
+})

--- a/app/behandling-sok/lib/request-builder.ts
+++ b/app/behandling-sok/lib/request-builder.ts
@@ -23,6 +23,8 @@ function harInnhold(k: Kriterium): boolean {
       return k.aktivitetTyper.length > 0
     case 'KRAVHODE_HAR_KONTROLLPUNKT':
       return k.kontrollpunktTyper.length > 0
+    case 'KRAVHODE_HAR_BEHANDLINGTYPE':
+      return k.behandlingTyper.length > 0
     case 'KRAV_GJELDER':
       return k.koder.length > 0
     case 'SAK_HAR_TYPE':

--- a/app/behandling-sok/lib/request-builder.ts
+++ b/app/behandling-sok/lib/request-builder.ts
@@ -1,0 +1,92 @@
+/**
+ * Bygger backend-request body fra (behandlingType + kriterier + visnings-parametre).
+ * Filtrerer bort tomme kriterier slik at backend ikke får meningsløse felter.
+ */
+
+import type { Kriterium } from './kriterier'
+import type { Aggregering, Tidsdimensjon } from './url-state'
+
+export const SCHEMA_VERSION = '1'
+
+function harInnhold(k: Kriterium): boolean {
+  switch (k.type) {
+    case 'HAR_STATUS':
+    case 'KRAVHODE_HAR_STATUS':
+      return k.statuser.length > 0
+    case 'HAR_PRIORITET':
+      return k.prioriteter.length > 0
+    case 'HAR_ANSVARLIG_TEAM':
+      return k.team.length > 0
+    case 'OPPRETTET_AV':
+      return k.identer.length > 0
+    case 'HAR_AKTIVITET_AV_TYPE':
+      return k.aktivitetTyper.length > 0
+    case 'KRAVHODE_HAR_KONTROLLPUNKT':
+      return k.kontrollpunktTyper.length > 0
+    case 'KRAV_GJELDER':
+      return k.koder.length > 0
+    case 'SAK_HAR_TYPE':
+      return k.sakstyper.length > 0
+    case 'KRAV_HAR_EIERENHET':
+      return k.eierenheter.length > 0
+    case 'TILHORER_BEHANDLINGSSERIE':
+      return k.uuid.length > 0
+    case 'OPPRETTET_I_PERIODE':
+    case 'FULLFORT_I_PERIODE':
+    case 'STOPPET_I_PERIODE':
+    case 'SIST_KJORT_I_PERIODE':
+      return k.fom.length > 0 && k.tom.length > 0
+    default:
+      return true
+  }
+}
+
+export function rensKriterier(kriterier: Kriterium[]): Kriterium[] {
+  return kriterier.filter(harInnhold)
+}
+
+export type TreffRequest = {
+  schemaVersion: string
+  behandlingType: string
+  kriterier: Kriterium[]
+  limit: number
+  cursor: { opprettet: string; behandlingId: number } | null
+}
+
+export function buildTreffRequest(
+  behandlingType: string,
+  kriterier: Kriterium[],
+  cursor: { opprettet: string; behandlingId: number } | null,
+  limit = 100,
+): TreffRequest {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    behandlingType,
+    kriterier: rensKriterier(kriterier),
+    limit,
+    cursor,
+  }
+}
+
+export type AntallOverTidRequest = {
+  schemaVersion: string
+  behandlingType: string
+  kriterier: Kriterium[]
+  aggregering: Aggregering
+  tidsdimensjon: Tidsdimensjon
+}
+
+export function buildAntallOverTidRequest(
+  behandlingType: string,
+  kriterier: Kriterium[],
+  aggregering: Aggregering,
+  tidsdimensjon: Tidsdimensjon,
+): AntallOverTidRequest {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    behandlingType,
+    kriterier: rensKriterier(kriterier),
+    aggregering,
+    tidsdimensjon,
+  }
+}

--- a/app/behandling-sok/lib/request-builder.ts
+++ b/app/behandling-sok/lib/request-builder.ts
@@ -62,6 +62,8 @@ function mapTilBackend(k: Kriterium): BackendKriterium {
       return { type: k.type, erBatch: k.verdi }
     case 'KRAV_HAR_EIERENHET':
       return { type: k.type, enhetsnr: k.eierenheter }
+    case 'HAR_ANSVARLIG_TEAM':
+      return { type: k.type, teams: k.team }
     case 'HAR_FEILET_KJORING':
       return k.siden ? { type: k.type, sidenDato: k.siden } : { type: k.type }
     default:

--- a/app/behandling-sok/lib/request-builder.ts
+++ b/app/behandling-sok/lib/request-builder.ts
@@ -41,14 +41,36 @@ function harInnhold(k: Kriterium): boolean {
   }
 }
 
-export function rensKriterier(kriterier: Kriterium[]): Kriterium[] {
-  return kriterier.filter(harInnhold)
+/** Et kriterium slik backend forventer å motta det (etter feltnavn-mapping). */
+export type BackendKriterium = { type: string; [key: string]: unknown }
+
+export function rensKriterier(kriterier: Kriterium[]): BackendKriterium[] {
+  // Filtrerer bort tomme kriterier OG mapper interne feltnavn til backend-DTO-felt.
+  // Backend-DTO-er ligger i `BehandlingSokKriterium.kt`; denne mappingen må holdes synkron.
+  return kriterier.filter(harInnhold).map((k) => mapTilBackend(k))
+}
+
+function mapTilBackend(k: Kriterium): BackendKriterium {
+  switch (k.type) {
+    case 'OPPRETTET_AV':
+      return { type: k.type, brukere: k.identer }
+    case 'TILHORER_BEHANDLINGSSERIE':
+      return { type: k.type, behandlingSerieId: k.uuid }
+    case 'ER_BATCH':
+      return { type: k.type, erBatch: k.verdi }
+    case 'KRAV_HAR_EIERENHET':
+      return { type: k.type, enhetsnr: k.eierenheter }
+    case 'HAR_FEILET_KJORING':
+      return k.siden ? { type: k.type, sidenDato: k.siden } : { type: k.type }
+    default:
+      return k
+  }
 }
 
 export type TreffRequest = {
   schemaVersion: string
   behandlingType: string
-  kriterier: Kriterium[]
+  kriterier: BackendKriterium[]
   limit: number
   cursor: { opprettet: string; behandlingId: number } | null
 }
@@ -71,7 +93,7 @@ export function buildTreffRequest(
 export type AntallOverTidRequest = {
   schemaVersion: string
   behandlingType: string
-  kriterier: Kriterium[]
+  kriterier: BackendKriterium[]
   aggregering: Aggregering
   tidsdimensjon: Tidsdimensjon
 }

--- a/app/behandling-sok/lib/sensitive-state.test.ts
+++ b/app/behandling-sok/lib/sensitive-state.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Kriterium } from './kriterier'
+import { fjernSensitive, hentSensitive, lagreSensitive, tomAlleSensitive } from './sensitive-state'
+
+// Minimal in-memory sessionStorage for node test-miljø.
+class MemoryStorage {
+  private store: Record<string, string> = {}
+  getItem(k: string) {
+    return Object.hasOwn(this.store, k) ? this.store[k] : null
+  }
+  setItem(k: string, v: string) {
+    this.store[k] = v
+  }
+  removeItem(k: string) {
+    delete this.store[k]
+  }
+  clear() {
+    this.store = {}
+  }
+  key(i: number) {
+    return Object.keys(this.store)[i] ?? null
+  }
+  get length() {
+    return Object.keys(this.store).length
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: stub window for node-tests
+const g = globalThis as any
+g.window = g.window ?? {}
+g.window.sessionStorage = new MemoryStorage()
+
+describe('sensitive-state (sessionStorage)', () => {
+  beforeEach(() => {
+    tomAlleSensitive()
+  })
+
+  it('returnerer tom liste når ingenting er lagret', () => {
+    expect(hentSensitive('hash1')).toEqual([])
+  })
+
+  it('lagrer og henter sensitive kriterier per query-hash', () => {
+    const k: Kriterium[] = [{ type: 'OPPRETTET_AV', identer: ['Z990123'] }]
+    lagreSensitive('hash1', k)
+    expect(hentSensitive('hash1')).toEqual(k)
+    expect(hentSensitive('hash2')).toEqual([])
+  })
+
+  it('lagring av tom liste fjerner entry', () => {
+    lagreSensitive('hash1', [{ type: 'OPPRETTET_AV', identer: ['Z990123'] }])
+    lagreSensitive('hash1', [])
+    expect(hentSensitive('hash1')).toEqual([])
+  })
+
+  it('fjernSensitive sletter spesifikk hash', () => {
+    lagreSensitive('hash1', [{ type: 'OPPRETTET_AV', identer: ['Z990123'] }])
+    lagreSensitive('hash2', [{ type: 'OPPRETTET_AV', identer: ['Z990456'] }])
+    fjernSensitive('hash1')
+    expect(hentSensitive('hash1')).toEqual([])
+    expect(hentSensitive('hash2')).not.toEqual([])
+  })
+
+  it('begrenser til 20 mest nylige entries', () => {
+    for (let i = 0; i < 25; i++) {
+      lagreSensitive(`hash${i}`, [{ type: 'OPPRETTET_AV', identer: [`Z${i}`] }])
+    }
+    // De 5 eldste skal være borte
+    expect(hentSensitive('hash0')).toEqual([])
+    expect(hentSensitive('hash24')).not.toEqual([])
+  })
+})

--- a/app/behandling-sok/lib/sensitive-state.ts
+++ b/app/behandling-sok/lib/sensitive-state.ts
@@ -14,7 +14,18 @@ const MAX_ENTRIES = 20
 
 type Lagring = Record<string, { kriterier: Kriterium[]; seq: number }>
 
-let nesteSeq = 1
+let nesteSeq = 0
+let nesteSeqInitialized = false
+
+function initNesteSeqFraStorage(data: Lagring): void {
+  if (nesteSeqInitialized) return
+  let max = 0
+  for (const entry of Object.values(data)) {
+    if (typeof entry?.seq === 'number' && entry.seq > max) max = entry.seq
+  }
+  nesteSeq = max + 1
+  nesteSeqInitialized = true
+}
 function getStorage(): Storage | null {
   if (typeof window === 'undefined') return null
   try {
@@ -57,6 +68,7 @@ export function lagreSensitive(queryHash: string, kriterier: Kriterium[]): void 
     return
   }
   const data = lesAlle()
+  initNesteSeqFraStorage(data)
   const seq = nesteSeq++
   data[queryHash] = { kriterier, seq }
   skrivAlle(data)
@@ -76,4 +88,6 @@ export function fjernSensitive(queryHash: string): void {
 export function tomAlleSensitive(): void {
   const s = getStorage()
   if (s) s.removeItem(STORAGE_KEY)
+  nesteSeq = 0
+  nesteSeqInitialized = false
 }

--- a/app/behandling-sok/lib/sensitive-state.ts
+++ b/app/behandling-sok/lib/sensitive-state.ts
@@ -1,0 +1,79 @@
+/**
+ * sessionStorage-lagring av sensitive kriterier (NAV-identer, behandlingsserie-UUID-er).
+ * Sensitive kriterier holdes ute av URL for å unngå at de havner i historikk, deling, og logger.
+ *
+ * - Lagres keyed på en query-hash slik at de bare assosieres med eksakt samme søk.
+ * - Begrenset volum (siste 20 query-hash) for å hindre uendelig vekst.
+ * - Tømmes automatisk ved sessionStorage-utløp (slutt på fane / browser).
+ */
+
+import type { Kriterium } from './kriterier'
+
+const STORAGE_KEY = 'verdande:behandling-sok:sensitive'
+const MAX_ENTRIES = 20
+
+type Lagring = Record<string, { kriterier: Kriterium[]; seq: number }>
+
+let nesteSeq = 1
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+function lesAlle(): Lagring {
+  const s = getStorage()
+  if (!s) return {}
+  const raw = s.getItem(STORAGE_KEY)
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') return parsed as Lagring
+  } catch {
+    // ignore corrupt data
+  }
+  return {}
+}
+
+function skrivAlle(data: Lagring): void {
+  const s = getStorage()
+  if (!s) return
+  // Behold de MAX_ENTRIES nyeste — eldste forsvinner først (LRU på seq).
+  const sortert = Object.entries(data).sort(([, a], [, b]) => b.seq - a.seq)
+  const beholdt = Object.fromEntries(sortert.slice(0, MAX_ENTRIES))
+  try {
+    s.setItem(STORAGE_KEY, JSON.stringify(beholdt))
+  } catch {
+    // QuotaExceeded — gi opp stille; ikke kritisk.
+  }
+}
+
+export function lagreSensitive(queryHash: string, kriterier: Kriterium[]): void {
+  if (kriterier.length === 0) {
+    fjernSensitive(queryHash)
+    return
+  }
+  const data = lesAlle()
+  const seq = nesteSeq++
+  data[queryHash] = { kriterier, seq }
+  skrivAlle(data)
+}
+
+export function hentSensitive(queryHash: string): Kriterium[] {
+  const data = lesAlle()
+  return data[queryHash]?.kriterier ?? []
+}
+
+export function fjernSensitive(queryHash: string): void {
+  const data = lesAlle()
+  delete data[queryHash]
+  skrivAlle(data)
+}
+
+export function tomAlleSensitive(): void {
+  const s = getStorage()
+  if (s) s.removeItem(STORAGE_KEY)
+}

--- a/app/behandling-sok/lib/url-state.test.ts
+++ b/app/behandling-sok/lib/url-state.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import type { Kriterium } from './kriterier'
+import {
+  deserializeStateFromSearchParams,
+  fjernSensitive,
+  hashCommittedState,
+  plukkSensitive,
+  serializeStateToSearchParams,
+} from './url-state'
+
+const baseSpec: Kriterium[] = [
+  { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+  { type: 'HAR_AKTIVITET_AV_TYPE', aktivitetTyper: ['FleksibelApSak_A412_X'], operator: 'OR' },
+  { type: 'KRAVHODE_HAR_KONTROLLPUNKT', kontrollpunktTyper: ['UTLAND'], operator: 'OR' },
+  { type: 'KRAVHODE_HAR_STATUS', statuser: ['MAN'] },
+]
+
+describe('serialize/deserialize roundtrip', () => {
+  it('beholder ikke-sensitive kriterier', () => {
+    const sp = serializeStateToSearchParams({
+      behandlingType: 'FleksibelApSak',
+      kriterier: baseSpec,
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.feil).toBeNull()
+    expect(r.state.behandlingType).toBe('FleksibelApSak')
+    expect(r.state.ikkeSensitiveKriterier).toEqual(baseSpec)
+    expect(r.state.visning).toBe('treff')
+  })
+  it('strippe sensitive kriterier fra URL', () => {
+    const k: Kriterium[] = [
+      ...baseSpec,
+      { type: 'OPPRETTET_AV', identer: ['Z990123'] },
+      { type: 'TILHORER_BEHANDLINGSSERIE', uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+    ]
+    const sp = serializeStateToSearchParams({
+      behandlingType: 'FleksibelApSak',
+      kriterier: k,
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    const dekoded = sp.toString()
+    expect(dekoded).not.toContain('Z990123')
+    expect(dekoded).not.toContain('a1b2c3d4')
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.state.ikkeSensitiveKriterier.find((x) => x.type === 'OPPRETTET_AV')).toBeUndefined()
+  })
+  it('utelater default-verdier fra URL for kompakthet', () => {
+    const sp = serializeStateToSearchParams({
+      behandlingType: 'FleksibelApSak',
+      kriterier: [],
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    expect(sp.has('visning')).toBe(false)
+    expect(sp.has('aggregering')).toBe(false)
+    expect(sp.has('tidsdimensjon')).toBe(false)
+  })
+  it('tar med graf-parametre når visning=antall-over-tid', () => {
+    const sp = serializeStateToSearchParams({
+      behandlingType: 'FleksibelApSak',
+      kriterier: [],
+      visning: 'antall-over-tid',
+      aggregering: 'UKE',
+      tidsdimensjon: 'FULLFORT',
+    })
+    expect(sp.get('visning')).toBe('antall-over-tid')
+    expect(sp.get('aggregering')).toBe('UKE')
+    expect(sp.get('tidsdimensjon')).toBe('FULLFORT')
+  })
+})
+
+describe('deserializeStateFromSearchParams — feilrobust', () => {
+  it('returnerer feilmelding for ugyldig base64', () => {
+    const sp = new URLSearchParams({ q: '!!!ikke-base64@@@' })
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.feil).not.toBeNull()
+  })
+  it('returnerer feilmelding for ikke-array JSON', () => {
+    const sp = new URLSearchParams({ q: Buffer.from('{"foo":"bar"}').toString('base64url') })
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.feil).not.toBeNull()
+  })
+  it('rapporterer ukjente kriterietyper i stedet for å filtrere stille', () => {
+    const data = [
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'NY_FREMTIDIG_KRITERIE', foo: 'bar' },
+    ]
+    const sp = new URLSearchParams({ q: Buffer.from(JSON.stringify(data)).toString('base64url') })
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.ukjenteKriterier).toHaveLength(1)
+    expect(r.ukjenteKriterier[0].type).toBe('NY_FREMTIDIG_KRITERIE')
+    expect(r.state.ikkeSensitiveKriterier).toHaveLength(1)
+  })
+  it('faller tilbake til defaults for ugyldig visning/aggregering', () => {
+    const sp = new URLSearchParams({ visning: 'foo', aggregering: 'bar' })
+    const r = deserializeStateFromSearchParams(sp)
+    expect(r.state.visning).toBe('treff')
+    expect(r.state.aggregering).toBe('MAANED')
+  })
+})
+
+describe('plukkSensitive / fjernSensitive', () => {
+  it('partisjonerer korrekt', () => {
+    const k: Kriterium[] = [
+      { type: 'OPPRETTET_I_PERIODE', fom: '2025-01-01', tom: '2025-12-31' },
+      { type: 'OPPRETTET_AV', identer: ['Z990123'] },
+    ]
+    expect(fjernSensitive(k)).toHaveLength(1)
+    expect(plukkSensitive(k)).toHaveLength(1)
+    expect(plukkSensitive(k)[0].type).toBe('OPPRETTET_AV')
+  })
+})
+
+describe('hashCommittedState', () => {
+  it('gir samme hash for samme state', () => {
+    const a = hashCommittedState({
+      behandlingType: 'FleksibelApSak',
+      ikkeSensitiveKriterier: baseSpec,
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    const b = hashCommittedState({
+      behandlingType: 'FleksibelApSak',
+      ikkeSensitiveKriterier: baseSpec,
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    expect(a).toBe(b)
+  })
+  it('endrer seg når kriterium endres', () => {
+    const a = hashCommittedState({
+      behandlingType: 'FleksibelApSak',
+      ikkeSensitiveKriterier: baseSpec,
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    const b = hashCommittedState({
+      behandlingType: 'FleksibelApSak',
+      ikkeSensitiveKriterier: baseSpec.slice(0, 2),
+      visning: 'treff',
+      aggregering: 'MAANED',
+      tidsdimensjon: 'OPPRETTET',
+    })
+    expect(a).not.toBe(b)
+  })
+})

--- a/app/behandling-sok/lib/url-state.ts
+++ b/app/behandling-sok/lib/url-state.ts
@@ -123,6 +123,10 @@ function validateKriteriumShape(raw: any): Kriterium | null {
       return isStrArr(raw.kontrollpunktTyper) && isOp(raw.operator)
         ? { type: 'KRAVHODE_HAR_KONTROLLPUNKT', kontrollpunktTyper: raw.kontrollpunktTyper, operator: raw.operator }
         : null
+    case 'KRAVHODE_HAR_BEHANDLINGTYPE':
+      return isStrArr(raw.behandlingTyper)
+        ? { type: 'KRAVHODE_HAR_BEHANDLINGTYPE', behandlingTyper: raw.behandlingTyper }
+        : null
     case 'KONTROLLPUNKT_ER_KRITISK':
       return { type: 'KONTROLLPUNKT_ER_KRITISK' }
     case 'KRAV_GJELDER':

--- a/app/behandling-sok/lib/url-state.ts
+++ b/app/behandling-sok/lib/url-state.ts
@@ -1,0 +1,240 @@
+/**
+ * Serialisering av committed søk-tilstand til/fra URL.
+ *
+ * Sensitive kriterier (NAV-identer, behandlingsserie-UUID-er) holdes utenfor URL og lagres i
+ * sessionStorage; se `sensitive-state.ts`.
+ */
+
+import { erKjentKriterieType, KRITERIE_DEFINISJONER, type KriterieType, type Kriterium } from './kriterier'
+
+export type Visning = 'treff' | 'antall-over-tid'
+export type Aggregering = 'DAG' | 'UKE' | 'MAANED' | 'KVARTAL' | 'AAR'
+export type Tidsdimensjon = 'OPPRETTET' | 'FULLFORT' | 'STOPPET' | 'SISTE_KJORING'
+
+export const ALLE_AGGREGERINGER: Aggregering[] = ['DAG', 'UKE', 'MAANED', 'KVARTAL', 'AAR']
+export const ALLE_TIDSDIMENSJONER: Tidsdimensjon[] = ['OPPRETTET', 'FULLFORT', 'STOPPET', 'SISTE_KJORING']
+
+export type CommittedState = {
+  behandlingType: string | null
+  /** Kun ikke-sensitive kriterier — sensitive merges inn fra sessionStorage. */
+  ikkeSensitiveKriterier: Kriterium[]
+  visning: Visning
+  aggregering: Aggregering
+  tidsdimensjon: Tidsdimensjon
+}
+
+export type DeserializeResult = {
+  state: CommittedState
+  ukjenteKriterier: { type: string; raw: unknown }[]
+  feil: string | null
+}
+
+export const DEFAULT_STATE: CommittedState = {
+  behandlingType: null,
+  ikkeSensitiveKriterier: [],
+  visning: 'treff',
+  aggregering: 'MAANED',
+  tidsdimensjon: 'OPPRETTET',
+}
+
+/** Maks lengde på `?q=`-payload før vi advarer. */
+export const MAX_Q_LENGTH = 1500
+
+function base64UrlEncode(str: string): string {
+  // btoa krever Latin1; bruk Buffer for å være safe i node (server-side).
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(str, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: btoa typed as global in browser
+  const b64 = (globalThis as any).btoa(unescape(encodeURIComponent(str)))
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(str: string): string | null {
+  try {
+    const padded = str.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice((str.length + 2) % 4)
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(padded, 'base64').toString('utf8')
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: atob typed as global in browser
+    return decodeURIComponent(escape((globalThis as any).atob(padded)))
+  } catch {
+    return null
+  }
+}
+
+export function fjernSensitive(kriterier: Kriterium[]): Kriterium[] {
+  return kriterier.filter((k) => !KRITERIE_DEFINISJONER[k.type].sensitiv)
+}
+
+export function plukkSensitive(kriterier: Kriterium[]): Kriterium[] {
+  return kriterier.filter((k) => KRITERIE_DEFINISJONER[k.type].sensitiv)
+}
+
+/**
+ * Per-type runtime-validering for å hindre at crafted URL-er gir kriterier med feil shape
+ * (f.eks. `{ type: 'OPPRETTET_AV', identer: 'noe' }` der `identer.map` ville krasje editoren).
+ * Returnerer null hvis raw ikke matcher forventet shape.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: validerer ukjent shape — `any` er tilsiktet her
+function validateKriteriumShape(raw: any): Kriterium | null {
+  if (!raw || typeof raw !== 'object' || typeof raw.type !== 'string') return null
+  const isStr = (v: unknown): v is string => typeof v === 'string'
+  const isNum = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v)
+  const isBool = (v: unknown): v is boolean => typeof v === 'boolean'
+  const isStrArr = (v: unknown): v is string[] => Array.isArray(v) && v.every(isStr)
+  const isNumArr = (v: unknown): v is number[] => Array.isArray(v) && v.every(isNum)
+  const isOp = (v: unknown): v is 'AND' | 'OR' => v === 'AND' || v === 'OR'
+
+  switch (raw.type as KriterieType) {
+    case 'OPPRETTET_I_PERIODE':
+    case 'FULLFORT_I_PERIODE':
+    case 'STOPPET_I_PERIODE':
+    case 'SIST_KJORT_I_PERIODE':
+      return isStr(raw.fom) && isStr(raw.tom) ? { type: raw.type, fom: raw.fom, tom: raw.tom } : null
+    case 'HAR_STATUS':
+    case 'KRAVHODE_HAR_STATUS':
+      return isStrArr(raw.statuser) ? { type: raw.type, statuser: raw.statuser } : null
+    case 'HAR_PRIORITET':
+      return isNumArr(raw.prioriteter) ? { type: 'HAR_PRIORITET', prioriteter: raw.prioriteter } : null
+    case 'HAR_ANSVARLIG_TEAM':
+      return isStrArr(raw.team) ? { type: 'HAR_ANSVARLIG_TEAM', team: raw.team } : null
+    case 'OPPRETTET_AV':
+      return isStrArr(raw.identer) ? { type: 'OPPRETTET_AV', identer: raw.identer } : null
+    case 'ER_BATCH':
+      return isBool(raw.verdi) ? { type: 'ER_BATCH', verdi: raw.verdi } : null
+    case 'TILHORER_BEHANDLINGSSERIE':
+      return isStr(raw.uuid) ? { type: 'TILHORER_BEHANDLINGSSERIE', uuid: raw.uuid } : null
+    case 'HAR_AKTIVITET_AV_TYPE':
+      return isStrArr(raw.aktivitetTyper) && isOp(raw.operator)
+        ? { type: 'HAR_AKTIVITET_AV_TYPE', aktivitetTyper: raw.aktivitetTyper, operator: raw.operator }
+        : null
+    case 'AKTIVITET_KJORT_FLERE_GANGER_ENN':
+      return isNum(raw.terskel) ? { type: 'AKTIVITET_KJORT_FLERE_GANGER_ENN', terskel: raw.terskel } : null
+    case 'HAR_AAPEN_MANUELL_BEHANDLING':
+      return { type: 'HAR_AAPEN_MANUELL_BEHANDLING' }
+    case 'HAR_AAPEN_BREVBESTILLING':
+      return { type: 'HAR_AAPEN_BREVBESTILLING' }
+    case 'HAR_FEILET_KJORING':
+      return raw.siden === null || raw.siden === undefined || isStr(raw.siden)
+        ? { type: 'HAR_FEILET_KJORING', siden: raw.siden ?? null }
+        : null
+    case 'KRAVHODE_HAR_KONTROLLPUNKT':
+      return isStrArr(raw.kontrollpunktTyper) && isOp(raw.operator)
+        ? { type: 'KRAVHODE_HAR_KONTROLLPUNKT', kontrollpunktTyper: raw.kontrollpunktTyper, operator: raw.operator }
+        : null
+    case 'KONTROLLPUNKT_ER_KRITISK':
+      return { type: 'KONTROLLPUNKT_ER_KRITISK' }
+    case 'KRAV_GJELDER':
+      return isStrArr(raw.koder) ? { type: 'KRAV_GJELDER', koder: raw.koder } : null
+    case 'SAK_HAR_TYPE':
+      return isStrArr(raw.sakstyper) ? { type: 'SAK_HAR_TYPE', sakstyper: raw.sakstyper } : null
+    case 'KRAV_HAR_EIERENHET':
+      return isStrArr(raw.eierenheter) ? { type: 'KRAV_HAR_EIERENHET', eierenheter: raw.eierenheter } : null
+    default:
+      return null
+  }
+}
+
+export function serializeStateToSearchParams(state: {
+  behandlingType: string | null
+  kriterier: Kriterium[]
+  visning: Visning
+  aggregering: Aggregering
+  tidsdimensjon: Tidsdimensjon
+}): URLSearchParams {
+  const sp = new URLSearchParams()
+  if (state.behandlingType) sp.set('behandlingType', state.behandlingType)
+  if (state.visning !== DEFAULT_STATE.visning) sp.set('visning', state.visning)
+  if (state.visning === 'antall-over-tid') {
+    if (state.aggregering !== DEFAULT_STATE.aggregering) sp.set('aggregering', state.aggregering)
+    if (state.tidsdimensjon !== DEFAULT_STATE.tidsdimensjon) sp.set('tidsdimensjon', state.tidsdimensjon)
+  }
+  const ikkeSensitive = fjernSensitive(state.kriterier)
+  if (ikkeSensitive.length > 0) {
+    const json = JSON.stringify(ikkeSensitive)
+    sp.set('q', base64UrlEncode(json))
+  }
+  return sp
+}
+
+export function deserializeStateFromSearchParams(sp: URLSearchParams): DeserializeResult {
+  const ukjente: { type: string; raw: unknown }[] = []
+  let feil: string | null = null
+
+  const behandlingType = sp.get('behandlingType') || null
+  const visningRaw = sp.get('visning')
+  const visning: Visning = visningRaw === 'antall-over-tid' ? 'antall-over-tid' : 'treff'
+  const aggregeringRaw = sp.get('aggregering')
+  const aggregering: Aggregering = ALLE_AGGREGERINGER.includes(aggregeringRaw as Aggregering)
+    ? (aggregeringRaw as Aggregering)
+    : DEFAULT_STATE.aggregering
+  const tidsdimensjonRaw = sp.get('tidsdimensjon')
+  const tidsdimensjon: Tidsdimensjon = ALLE_TIDSDIMENSJONER.includes(tidsdimensjonRaw as Tidsdimensjon)
+    ? (tidsdimensjonRaw as Tidsdimensjon)
+    : DEFAULT_STATE.tidsdimensjon
+
+  const ikkeSensitiveKriterier: Kriterium[] = []
+  const q = sp.get('q')
+  if (q) {
+    const decoded = base64UrlDecode(q)
+    if (!decoded) {
+      feil = 'Søkeparameteren q kunne ikke dekodes'
+    } else {
+      try {
+        const parsed = JSON.parse(decoded)
+        if (!Array.isArray(parsed)) {
+          feil = 'Søkeparameteren q er ikke et array'
+        } else {
+          for (const raw of parsed) {
+            if (raw && typeof raw === 'object' && 'type' in raw) {
+              const type = String((raw as { type: unknown }).type)
+              if (erKjentKriterieType(type)) {
+                const validert = validateKriteriumShape(raw)
+                if (validert) {
+                  ikkeSensitiveKriterier.push(validert)
+                } else {
+                  // Kjent type, men shape er feil — fail loud (crafted URL).
+                  ukjente.push({ type, raw })
+                }
+              } else {
+                ukjente.push({ type, raw })
+              }
+            } else {
+              feil = 'Et kriterium mangler type-felt'
+            }
+          }
+        }
+      } catch {
+        feil = 'Søkeparameteren q er ikke gyldig JSON'
+      }
+    }
+  }
+
+  return {
+    state: {
+      behandlingType,
+      ikkeSensitiveKriterier,
+      visning,
+      aggregering,
+      tidsdimensjon,
+    },
+    ukjenteKriterier: ukjente,
+    feil,
+  }
+}
+
+/**
+ * Stabil hash av committed-state for bruk som key i sessionStorage og useEffect-deps.
+ * Bruker JSON.stringify med sortert array-order; ikke kryptografisk sikker.
+ */
+export function hashCommittedState(state: CommittedState): string {
+  const normalized = {
+    bt: state.behandlingType,
+    v: state.visning,
+    a: state.aggregering,
+    t: state.tidsdimensjon,
+    k: state.ikkeSensitiveKriterier,
+  }
+  return JSON.stringify(normalized)
+}

--- a/app/behandling-sok/metadata-cache.server.ts
+++ b/app/behandling-sok/metadata-cache.server.ts
@@ -1,0 +1,92 @@
+/**
+ * Server-side cache for `/api/behandling/sok/metadata/{behandlingType}`.
+ *
+ * - TTL 60s — etter det refetcher vi alltid for å plukke opp ny `metadataVersion`.
+ * - In-flight Promise-dedupe for å hindre thundering herd ved samtidige cache-miss.
+ * - Per server-instans (best-effort i NAIS-multi-pod-deploy).
+ */
+
+import { apiGet } from '~/services/api.server'
+
+export type Kontrollpunkt = { kode: string; dekodeTekst: string }
+
+export type BehandlingMetadata = {
+  schemaVersion: string
+  metadataVersion: string
+  generatedAt: string
+  behandlingType: string
+  supportedAktivitetTyper: string[]
+  observedAktivitetTyper: string[]
+  behandlingStatuser: string[]
+  ansvarligeTeam: string[]
+  kravStatuser: string[]
+  kontrollpunktTyper: Kontrollpunkt[]
+  kravGjelderKoder: string[]
+  sakstyper: string[]
+  eierenheter: string[]
+}
+
+const TTL_MS = 60_000
+
+const cache = new Map<string, { data: BehandlingMetadata; fetchedAt: number }>()
+const inFlight = new Map<string, Promise<BehandlingMetadata>>()
+
+export async function hentBehandlingMetadata(behandlingType: string, request: Request): Promise<BehandlingMetadata> {
+  const now = Date.now()
+  const cached = cache.get(behandlingType)
+  if (cached && now - cached.fetchedAt < TTL_MS) {
+    return cached.data
+  }
+
+  const eksisterende = inFlight.get(behandlingType)
+  if (eksisterende) return eksisterende
+
+  const promise = apiGet<BehandlingMetadata>(
+    `/api/behandling/sok/metadata/${encodeURIComponent(behandlingType)}`,
+    request,
+  )
+    .then((data) => {
+      cache.set(behandlingType, { data, fetchedAt: Date.now() })
+      return data
+    })
+    .finally(() => {
+      inFlight.delete(behandlingType)
+    })
+
+  inFlight.set(behandlingType, promise)
+  return promise
+}
+
+export type BehandlingstyperResponse = { typer: string[] }
+
+const TYPER_TTL_MS = 60_000
+let typerCache: { data: string[]; fetchedAt: number } | null = null
+let typerInFlight: Promise<string[]> | null = null
+
+export async function hentBehandlingstyper(request: Request): Promise<string[]> {
+  const now = Date.now()
+  if (typerCache && now - typerCache.fetchedAt < TYPER_TTL_MS) {
+    return typerCache.data
+  }
+  if (typerInFlight) return typerInFlight
+
+  typerInFlight = apiGet<BehandlingstyperResponse>('/api/behandling/sok/metadata/typer', request)
+    .then((res) => {
+      const data = res.typer ?? []
+      typerCache = { data, fetchedAt: Date.now() }
+      return data
+    })
+    .finally(() => {
+      typerInFlight = null
+    })
+
+  return typerInFlight
+}
+
+/** Test-helper for å nullstille cache mellom tester. */
+export function _resetCache() {
+  cache.clear()
+  inFlight.clear()
+  typerCache = null
+  typerInFlight = null
+}

--- a/app/behandling-sok/metadata-cache.server.ts
+++ b/app/behandling-sok/metadata-cache.server.ts
@@ -25,6 +25,7 @@ export type BehandlingMetadata = {
   kravGjelderKoder: string[]
   sakstyper: string[]
   eierenheter: string[]
+  kravhodeBehandlingTyper: string[]
 }
 
 const TTL_MS = 60_000

--- a/app/behandling-sok/metadata-cache.server.ts
+++ b/app/behandling-sok/metadata-cache.server.ts
@@ -58,7 +58,12 @@ export async function hentBehandlingMetadata(behandlingType: string, request: Re
   return promise
 }
 
-export type BehandlingstyperResponse = { typer: string[] } | string[]
+export type BehandlingstyperResponse = {
+  schemaVersion?: string
+  metadataVersion?: string
+  generatedAt?: string
+  behandlingTyper: string[]
+}
 
 const TYPER_TTL_MS = 60_000
 let typerCache: { data: string[]; fetchedAt: number } | null = null
@@ -73,13 +78,8 @@ export async function hentBehandlingstyper(request: Request): Promise<string[]> 
 
   typerInFlight = apiGet<BehandlingstyperResponse>('/api/behandling/sok/metadata/typer', request)
     .then((res) => {
-      // Backend kan returnere enten { typer: [...] } eller string[] direkte — vær tolerant.
-      const data = Array.isArray(res) ? res : (res?.typer ?? [])
-      logger.info(
-        `behandling-sok: hentet ${data.length} behandlingstyper (raw shape: ${
-          Array.isArray(res) ? 'array' : typeof res
-        }${!Array.isArray(res) && res ? `, keys=[${Object.keys(res).join(',')}]` : ''})`,
-      )
+      const data = res?.behandlingTyper ?? []
+      logger.info(`behandling-sok: hentet ${data.length} behandlingstyper`)
       typerCache = { data, fetchedAt: Date.now() }
       return data
     })

--- a/app/behandling-sok/metadata-cache.server.ts
+++ b/app/behandling-sok/metadata-cache.server.ts
@@ -57,7 +57,7 @@ export async function hentBehandlingMetadata(behandlingType: string, request: Re
   return promise
 }
 
-export type BehandlingstyperResponse = { typer: string[] }
+export type BehandlingstyperResponse = { typer: string[] } | string[]
 
 const TYPER_TTL_MS = 60_000
 let typerCache: { data: string[]; fetchedAt: number } | null = null
@@ -72,7 +72,8 @@ export async function hentBehandlingstyper(request: Request): Promise<string[]> 
 
   typerInFlight = apiGet<BehandlingstyperResponse>('/api/behandling/sok/metadata/typer', request)
     .then((res) => {
-      const data = res.typer ?? []
+      // Backend kan returnere enten { typer: [...] } eller string[] direkte — vær tolerant.
+      const data = Array.isArray(res) ? res : (res?.typer ?? [])
       typerCache = { data, fetchedAt: Date.now() }
       return data
     })

--- a/app/behandling-sok/metadata-cache.server.ts
+++ b/app/behandling-sok/metadata-cache.server.ts
@@ -7,6 +7,7 @@
  */
 
 import { apiGet } from '~/services/api.server'
+import { logger } from '~/services/logger.server'
 
 export type Kontrollpunkt = { kode: string; dekodeTekst: string }
 
@@ -74,6 +75,11 @@ export async function hentBehandlingstyper(request: Request): Promise<string[]> 
     .then((res) => {
       // Backend kan returnere enten { typer: [...] } eller string[] direkte — vær tolerant.
       const data = Array.isArray(res) ? res : (res?.typer ?? [])
+      logger.info(
+        `behandling-sok: hentet ${data.length} behandlingstyper (raw shape: ${
+          Array.isArray(res) ? 'array' : typeof res
+        }${!Array.isArray(res) && res ? `, keys=[${Object.keys(res).join(',')}]` : ''})`,
+      )
       typerCache = { data, fetchedAt: Date.now() }
       return data
     })

--- a/app/behandling-sok/metadata-cache.test.ts
+++ b/app/behandling-sok/metadata-cache.test.ts
@@ -21,19 +21,18 @@ describe('hentBehandlingstyper', () => {
     mockApiGet.mockReset()
   })
 
-  test('aksepterer { typer: string[] }-shape', async () => {
-    mockApiGet.mockResolvedValue({ typer: ['A', 'B', 'C'] })
+  test('mapper { behandlingTyper }-shape fra backend', async () => {
+    mockApiGet.mockResolvedValue({
+      schemaVersion: '1',
+      metadataVersion: 'm',
+      generatedAt: '2026-01-01T00:00:00',
+      behandlingTyper: ['A', 'B', 'C'],
+    })
     const res = await hentBehandlingstyper(new Request('http://x'))
     expect(res).toEqual(['A', 'B', 'C'])
   })
 
-  test('aksepterer string[]-shape direkte', async () => {
-    mockApiGet.mockResolvedValue(['A', 'B'])
-    const res = await hentBehandlingstyper(new Request('http://x'))
-    expect(res).toEqual(['A', 'B'])
-  })
-
-  test('returnerer tom liste hvis verken array eller { typer }', async () => {
+  test('returnerer tom liste når behandlingTyper mangler', async () => {
     mockApiGet.mockResolvedValue({})
     const res = await hentBehandlingstyper(new Request('http://x'))
     expect(res).toEqual([])

--- a/app/behandling-sok/metadata-cache.test.ts
+++ b/app/behandling-sok/metadata-cache.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/services/auth.server', () => ({
+  requireAccessToken: vi.fn().mockResolvedValue('test-token'),
+}))
+
+vi.mock('~/services/env.server', () => ({
+  env: { penUrl: 'http://pen-test', aldeBehandlingUrlTemplate: '', psakSakUrlTemplate: '' },
+  isAldeLinkEnabled: false,
+  isDevelopment: false,
+}))
+
+const mockApiGet = vi.fn()
+vi.mock('~/services/api.server', () => ({ apiGet: mockApiGet }))
+
+const { hentBehandlingstyper, _resetCache } = await import('./metadata-cache.server')
+
+describe('hentBehandlingstyper', () => {
+  beforeEach(() => {
+    _resetCache()
+    mockApiGet.mockReset()
+  })
+
+  test('aksepterer { typer: string[] }-shape', async () => {
+    mockApiGet.mockResolvedValue({ typer: ['A', 'B', 'C'] })
+    const res = await hentBehandlingstyper(new Request('http://x'))
+    expect(res).toEqual(['A', 'B', 'C'])
+  })
+
+  test('aksepterer string[]-shape direkte', async () => {
+    mockApiGet.mockResolvedValue(['A', 'B'])
+    const res = await hentBehandlingstyper(new Request('http://x'))
+    expect(res).toEqual(['A', 'B'])
+  })
+
+  test('returnerer tom liste hvis verken array eller { typer }', async () => {
+    mockApiGet.mockResolvedValue({})
+    const res = await hentBehandlingstyper(new Request('http://x'))
+    expect(res).toEqual([])
+  })
+})

--- a/app/components/venstre-meny/VenstreMeny.tsx
+++ b/app/components/venstre-meny/VenstreMeny.tsx
@@ -9,6 +9,7 @@ import {
   GavelIcon,
   HandShakeHeartIcon,
   HouseIcon,
+  MagnifyingGlassIcon,
   NumberListIcon,
   PersonGroupIcon,
   PersonRectangleIcon,
@@ -255,6 +256,17 @@ export default function VenstreMeny(props: Props) {
                   <HandShakeHeartIcon title="Alde oppfølging" fontSize="1.5rem" />
                 </span>
                 <span className={styles.menyTekst}>Alde oppfølging</span>
+              </NavLink>
+            </li>
+          )}
+
+          {harTilgang(me, 'SE_BEHANDLINGER') && (
+            <li>
+              <NavLink to="/behandling-sok" className={({ isActive }) => (isActive ? styles.active : '')}>
+                <span className={styles.menyIkon}>
+                  <MagnifyingGlassIcon title="Behandlingssøk" fontSize="1.5rem" />
+                </span>
+                <span className={styles.menyTekst}>Behandlingssøk</span>
               </NavLink>
             </li>
           )}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -260,6 +260,10 @@ export default [
     route('manuell-behandling', 'manuell-behandling/index.tsx'),
     route('manuell-behandling-uttrekk', 'manuell-behandling/uttrekk.tsx'),
 
+    route('behandling-sok', 'behandling-sok/behandling-sok.tsx'),
+    route('behandling-sok/api/treff', 'behandling-sok/api.treff.ts'),
+    route('behandling-sok/api/antall', 'behandling-sok/api.antall.ts'),
+
     route('omregning', 'omregning/omregning._index.tsx'),
     route('omregning/behandlinger', 'omregning/omregning.behandlinger.tsx'),
     route('omregning/omregning', 'omregning/omregning.omregning.tsx'),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -263,6 +263,7 @@ export default [
     route('behandling-sok', 'behandling-sok/behandling-sok.tsx'),
     route('behandling-sok/api/treff', 'behandling-sok/api.treff.ts'),
     route('behandling-sok/api/antall', 'behandling-sok/api.antall.ts'),
+    route('behandling-sok/api/metadata', 'behandling-sok/api.metadata.ts'),
 
     route('omregning', 'omregning/omregning._index.tsx'),
     route('omregning/behandlinger', 'omregning/omregning.behandlinger.tsx'),


### PR DESCRIPTION
Nytt verktøy `/behandling-sok` som lar oss bygge generiske kriteriebaserte spørringer mot pensjon-pen sitt nye `/api/behandling/sok/*`-endepunkt, med to visninger:

- **Treff** — paginerte rader med behandlingId, status, ansvarlig team, kravId, opprettet/ferdig/stoppet/sisteKjøring.
- **Antall over tid** — bucketed antall (DAG/UKE/MÅNED/KVARTAL/ÅR) for valgt tidsdimensjon (OPPRETTET/FULLFØRT/STOPPET/SISTE_KJORING), graf + tabell.

## Kriterier

22 kriterietyper i fire grupper (Tid, Behandling, Aktiviteter, Krav & sak), bl.a. periode-filtre (★ — minst ett kreves), `HAR_AKTIVITET_AV_TYPE` med AND/OR, `KRAVHODE_HAR_KONTROLLPUNKT`, `KRAVHODE_HAR_BEHANDLINGTYPE`, `OPPRETTET_AV` (NAV-identer), `TILHORER_BEHANDLINGSSERIE` (UUID), m.fl. Sensitive kriterier (NAV-identer + UUID) holdes ute av URL og lagres i sessionStorage med LRU-cap.

## Metadata-cache

Server-side TTL-cache (60s) + in-flight Promise-dedupe for `/api/behandling/sok/metadata/typer` og `/api/behandling/sok/metadata/{type}` for å fylle dropdowns og dekode aktivitetstyper.

## URL-state

Alle ikke-sensitive kriterier serialiseres til URL (`?q=...`) for delbar/bokmerkbar tilstand. Runtime shape-validering ved deserialisering hindrer at korrupte URL-er krasjer editorene; ukjente kriterietyper blokkerer søk og varsler brukeren.

## Reviewfunn adressert

Begge `code-review` (GPT-5.3-codex) og `rubber-duck` (Opus) ble kjørt på branchen. Adresserte blocking-funn:

1. **`HAR_ANSVARLIG_TEAM` feltnavn** — backend-DTO bruker `teams`, intern modell brukte `team`. Mappes nå i `mapTilBackend` + dedikert test.
2. **Backend-DTO feltnavn** generelt — flere kriterier (`OPPRETTET_AV`, `TILHORER_BEHANDLINGSSERIE`, `ER_BATCH`, `KRAV_HAR_EIERENHET`, `HAR_FEILET_KJORING`) hadde mismatch som er fikset i `rensKriterier`.
3. **Klient-feil fra fetchers** — `{ error }` fra resource routes vises nå som `Alert` istedenfor å bli stille svelget.
4. **Sensitive search fall-through** — `?s=1` uten data i sessionStorage viser nå eksplisitt warning og blokkerer rendering av tom resultattabell.
5. **Sensitive-state LRU seq-counter** — initialiseres fra `max(seq)+1` etter page reload slik at nye entries ikke kuttes bort i trim.

## Kjent oppfølging (egne PR-er)

- Metadata-fetch på `draftBehandlingType` (i dag bundet til `committed.behandlingType` — krever client-side metadata-fetcher).
- `LimInnJsonModal` bør gjenbruke `validateKriteriumShape` fra url-state.
- Frontend-validering kan utvides med metadata-whitelist-sjekk; i dag stoler vi på 400 fra backend.

## Definition of Done

- ✅ `npm run check` (Biome)
- ✅ `npm run typecheck`
- ✅ `npm test` (250 tester)
- ✅ `npm run test:stories` (213 stories)
- ✅ `npm run build`

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli/tree/trunk/copilot)