### PR TITLE
fix: rad-spesifikk uttrekk-nedlasting i manuell behandling

### DIFF
--- a/app/manuell-behandling/ManuellBehandlingActionMenu.tsx
+++ b/app/manuell-behandling/ManuellBehandlingActionMenu.tsx
@@ -1,10 +1,11 @@
 import { MenuElipsisVerticalIcon } from '@navikt/aksel-icons'
 import { ActionMenu, Button } from '@navikt/ds-react'
-import { useSearchParams } from 'react-router'
 
-export function ManuellBehandlingActionMenu() {
-  const [searchParams] = useSearchParams()
+type Props = {
+  uttrekkHref: string
+}
 
+export function ManuellBehandlingActionMenu({ uttrekkHref }: Props) {
   return (
     <ActionMenu>
       <ActionMenu.Trigger>
@@ -16,12 +17,7 @@ export function ManuellBehandlingActionMenu() {
         />
       </ActionMenu.Trigger>
       <ActionMenu.Content>
-        <ActionMenu.Item
-          as="a"
-          href={`/manuell-behandling-uttrekk?${searchParams.toString()}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <ActionMenu.Item as="a" href={uttrekkHref} target="_blank" rel="noopener noreferrer">
           Last ned json-uttrekk
         </ActionMenu.Item>
       </ActionMenu.Content>

--- a/app/manuell-behandling/index.tsx
+++ b/app/manuell-behandling/index.tsx
@@ -114,6 +114,30 @@ function sumAntall(rows: ManuellBehandlingOppsummering[]): number {
   return rows.reduce((acc, r) => acc + (r.antall ?? 0), 0)
 }
 
+function buildUttrekkHref(
+  fomDato: string,
+  tomDato: string,
+  rowFacets: Partial<Record<FacetKey, string | null>>,
+  activeFilters: Partial<Record<FacetKey, string[]>>,
+): string {
+  const params = new URLSearchParams()
+  params.set('fomDato', fomDato)
+  params.set('tomDato', tomDato)
+
+  for (const facet of FACETS) {
+    if (facet in rowFacets) {
+      params.set(facet, encodeValue(rowFacets[facet] ?? null))
+    } else {
+      const values = activeFilters[facet]
+      if (values?.length) {
+        for (const v of values) params.append(facet, v)
+      }
+    }
+  }
+
+  return `/manuell-behandling-uttrekk?${params.toString()}`
+}
+
 function applyFilters(
   rows: ManuellBehandlingOppsummering[],
   filters: Partial<Record<FacetKey, string[]>>,
@@ -514,7 +538,21 @@ export default function ManuellBehandlingOppsummeringRoute({ loaderData }: Route
                           {((r.antall * 100) / total).toFixed(1)} %
                         </Table.DataCell>
                         <Table.DataCell>
-                          <ManuellBehandlingActionMenu />
+                          <ManuellBehandlingActionMenu
+                            uttrekkHref={buildUttrekkHref(
+                              fomDato,
+                              tomDato,
+                              {
+                                behandlingType: r.behandlingType,
+                                kategori: r.kategori,
+                                fagomrade: r.fagomrade,
+                                oppgaveKode: r.oppgaveKode,
+                                underkategoriKode: r.underkategoriKode,
+                                prioritetKode: r.prioritetKode,
+                              },
+                              filters,
+                            )}
+                          />
                         </Table.DataCell>
                       </Table.Row>
                     ))}
@@ -548,7 +586,9 @@ export default function ManuellBehandlingOppsummeringRoute({ loaderData }: Route
                         {((gr.antall * 100) / total).toFixed(1)} %
                       </Table.DataCell>
                       <Table.DataCell>
-                        <ManuellBehandlingActionMenu />
+                        <ManuellBehandlingActionMenu
+                          uttrekkHref={buildUttrekkHref(fomDato, tomDato, gr.values, filters)}
+                        />
                       </Table.DataCell>
                     </Table.Row>
                   ))}


### PR DESCRIPTION
Per-rad "Last ned json-uttrekk" lastet ned hele datasettet i stedet for kun raden man klikket på. Fikser dette ved å bygge uttrekk-URL med radens spesifikke facet-verdier.

- Null-verdier (underkategoriKode, prioritetKode) kodes som __NULL__ for å filtrere eksplisitt på null i backend
- Grupperte rader inkluderer aktive sidefiltre for facetter som ikke inngår i grupperingen
- ManuellBehandlingActionMenu tar nå ferdig-bygget href i stedet for å lese searchParams selv