### PR TITLE
Legg til default npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
+registry=https://registry.npmjs.org/
+
 engine-strict=true
 fund=false


### PR DESCRIPTION
Etter at vi gikk over til pnpm så sliter dependabot med å skjønne at man skal bruke npmjs som default registry og ikke GitHub (og sliter med å oppdatere siden alt ikke ligger der). Denne PR'en fikser det.