### PR TITLE
fix(ci): deploy med image-digest for å matche SBOM-attestering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,7 @@ jobs:
         shell: bash
         run: |
           TIME=$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M)
-          COMMIT=$(git rev-parse --short=12 HEAD)
           echo "TIME=$TIME" >> $GITHUB_OUTPUT
-          echo "VERSION=$TIME-$COMMIT" >> $GITHUB_OUTPUT
 
       - name: NAIS login
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -104,7 +102,7 @@ jobs:
       - uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # v2
         name: 'Deploy to NAIS'
         env:
-          IMAGE: "${{ needs.build.outputs.image }}"
+          IMAGE: "${{ needs.build.outputs.image-digest }}"
           RESOURCE: .nais/nais.yaml
           CLUSTER: '${{ matrix.cluster }}'
           VARS: ${{matrix.vars}}


### PR DESCRIPTION
Vi endrer deploy til å bruke needs.build.outputs.image-digest i stedet for tag. Årsaken er at SBOM-attestering (attest-sign) skjer på digest-referansen, og NAIS kan ellers vise «missing SBOM» når deploy peker på en tag som ikke matcher samme immutable image-referanse.

Fjerner også ubrukt VERSION-output i workflowen for å redusere støy.