### PR TITLE
Bruk Chainguard baseimage for å redusere antall sårbarheter fra Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim
 
 ENV TZ="Europe/Oslo"
 


### PR DESCRIPTION
Dette er funnene med dette imaget

<img width="1285" height="249" alt="Skjermbilde 2026-06-13 kl  14 40 02" src="https://github.com/user-attachments/assets/8390f9fe-f4d2-4e07-b599-aecf62b3b390" />

