### PR TITLE
fix: vis feilmelding ved timeout/feil på strømmet fremdriftsdata

### DIFF
--- a/app/behandling/BehandlingCard.tsx
+++ b/app/behandling/BehandlingCard.tsx
@@ -14,6 +14,7 @@ import {
   XMarkOctagonIcon,
 } from '@navikt/aksel-icons'
 import {
+  Alert,
   BodyLong,
   Box,
   Button,
@@ -545,7 +546,16 @@ export default function BehandlingCard(props: Props) {
                       </Entry>
                     }
                   >
-                    <Await resolve={props.detaljertFremdrift}>
+                    <Await
+                      resolve={props.detaljertFremdrift}
+                      errorElement={
+                        <Entry labelText={'Fremdrift'}>
+                          <Alert variant="warning" size="small" inline>
+                            Kunne ikke laste fremdriftsdata
+                          </Alert>
+                        </Entry>
+                      }
+                    >
                       {(detaljertFremdrift) =>
                         detaljertFremdrift && (
                           <Entry labelText={'Fremdrift'}>
@@ -671,7 +681,15 @@ export default function BehandlingCard(props: Props) {
                   padding={'space-16'}
                 >
                   <Suspense fallback={<Loader size="3xlarge" title="Venter..." />}>
-                    <Await resolve={props.detaljertFremdrift}>
+                    <Await
+                      resolve={props.detaljertFremdrift}
+                      errorElement={
+                        <Alert variant="warning">
+                          Fremdriftsdata kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste
+                          siden på nytt.
+                        </Alert>
+                      }
+                    >
                       {(detaljertFremdrift) =>
                         detaljertFremdrift && (
                           <BehandlingBatchDetaljertFremdriftBarChart detaljertFremdrift={detaljertFremdrift} />


### PR DESCRIPTION
## Problem

Ved lasting av behandlingssiden (f.eks. `/behandling/108539333`) hentes `detaljertFremdrift` som et strømmet (deferred) løfte. Ved tidsavbrudd eller andre feil ble feilen propagert til rot-error-boundary, noe som krasjet hele siden med «Operasjon feilet».

## Løsning

La til `errorElement`-prop på begge `<Await>`-komponentene i `BehandlingCard.tsx`:

- **Fremdrift-progress-bar** (header): Viser en kompakt `Alert variant="warning"` der progress-baren ellers vises
- **Batch-fremdrift-barchart** (høyre panel): Viser en `Alert variant="warning"` med melding om at data ikke kunne lastes og tips om å laste siden på nytt

Resten av siden fungerer normalt selv om fremdriftsdata feiler.

Samme mønster som allerede brukes i `LokiLogsTableLoader.tsx`.