### PR TITLE
fix: legg til errorElement på alle <Await>-komponenter uten feilhåndtering

### DIFF
--- a/app/adhocbrev/adhoc-brev.stories.tsx
+++ b/app/adhocbrev/adhoc-brev.stories.tsx
@@ -24,3 +24,11 @@ export const Empty: Story = {
       behandlinger: mockBehandlingerPage([], { empty: true }),
     }),
 }
+
+export const FeilendeData: Story = {
+  tags: ['error-expected'],
+  render: () =>
+    renderWithLoader(AdhocBrev, {
+      behandlinger: Promise.reject(new Error('Tidsavbrudd')),
+    }),
+}

--- a/app/adhocbrev/adhoc-brev.tsx
+++ b/app/adhocbrev/adhoc-brev.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Box, Button, Heading, Select, Skeleton, TextField, VStack } from '@navikt/ds-react'
+import { Alert, BodyLong, Box, Button, Heading, Select, Skeleton, TextField, VStack } from '@navikt/ds-react'
 import { Suspense, useState } from 'react'
 import { Await, Form, redirect, useNavigation } from 'react-router'
 import { decodeBehandling } from '~/common/decodeBehandling'
@@ -107,7 +107,15 @@ export default function AdhocBrev({ loaderData }: Route.ComponentProps) {
         Eksisterende ad-hoc brevbestillinger
       </Heading>
       <Suspense fallback={<Skeleton variant="rectangle" width="100%" height={407} />}>
-        <Await resolve={behandlinger}>
+        <Await
+          resolve={behandlinger}
+          errorElement={
+            <Alert variant="warning">
+              Brevbestillinger kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden på
+              nytt.
+            </Alert>
+          }
+        >
           {(it) => (
             <BehandlingerTable
               inkluderFortsett={false}

--- a/app/avstemming/avstemming.stories.tsx
+++ b/app/avstemming/avstemming.stories.tsx
@@ -24,3 +24,11 @@ export const Empty: Story = {
       behandlinger: mockBehandlingerPage([], { empty: true }),
     }),
 }
+
+export const FeilendeData: Story = {
+  tags: ['error-expected'],
+  render: () =>
+    renderWithLoader(Avstemming, {
+      behandlinger: Promise.reject(new Error('Tidsavbrudd')),
+    }),
+}

--- a/app/avstemming/avstemming.tsx
+++ b/app/avstemming/avstemming.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   BodyLong,
   Box,
   Button,
@@ -214,7 +215,14 @@ export default function Avstemming({ loaderData }: Route.ComponentProps) {
         Eksisterende avstemminger
       </Heading>
       <Suspense fallback={<Skeleton variant="rectangle" width="100%" height={407} />}>
-        <Await resolve={behandlinger}>
+        <Await
+          resolve={behandlinger}
+          errorElement={
+            <Alert variant="warning">
+              Avstemminger kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden på nytt.
+            </Alert>
+          }
+        >
           {(it) => (
             <BehandlingerTable
               inkluderFortsett={false}

--- a/app/behandling/behandling.$behandlingId.avhengigeBehandlinger.tsx
+++ b/app/behandling/behandling.$behandlingId.avhengigeBehandlinger.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@navikt/ds-react'
+import { Alert, Skeleton } from '@navikt/ds-react'
 import { Suspense } from 'react'
 import { Await } from 'react-router'
 import invariant from 'tiny-invariant'
@@ -34,7 +34,15 @@ export default function AvhengigeBehandlinger({ loaderData }: Route.ComponentPro
 
   return (
     <Suspense fallback={<Skeleton variant="text" width="100%" />}>
-      <Await resolve={avhengigeBehandlinger}>
+      <Await
+        resolve={avhengigeBehandlinger}
+        errorElement={
+          <Alert variant="warning">
+            Avhengige behandlinger kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden
+            på nytt.
+          </Alert>
+        }
+      >
         {(it) => <AvhengigeBehandlingerElement avhengigeBehandlinger={it} />}
       </Await>
     </Suspense>

--- a/app/behandling/behandling.$behandlingId.ikkeFullforteAktiviteter.tsx
+++ b/app/behandling/behandling.$behandlingId.ikkeFullforteAktiviteter.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from '@navikt/ds-react'
+import { Alert, Skeleton } from '@navikt/ds-react'
 import { Suspense } from 'react'
 import { Await } from 'react-router'
 import invariant from 'tiny-invariant'
@@ -21,7 +21,15 @@ export default function AvhengigeBehandlinger({ loaderData }: Route.ComponentPro
 
   return (
     <Suspense fallback={<Skeleton variant="text" width="100%" />}>
-      <Await resolve={ikkeFullforteAktiviteter}>
+      <Await
+        resolve={ikkeFullforteAktiviteter}
+        errorElement={
+          <Alert variant="warning">
+            Uferdige aktiviteter kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden på
+            nytt.
+          </Alert>
+        }
+      >
         {(it) => <IkkeFullforteAktiviteter ikkeFullforteAktiviteter={it} />}
       </Await>
     </Suspense>

--- a/app/dashboard/route.stories.tsx
+++ b/app/dashboard/route.stories.tsx
@@ -48,3 +48,11 @@ export const MedVisAlleKnapp: Story = {
       }),
     }),
 }
+
+export const FeilendeData: Story = {
+  tags: ['error-expected'],
+  render: () =>
+    renderWithLoader(Dashboard, {
+      loadingDashboardResponse: Promise.reject(new Error('Tidsavbrudd')),
+    }),
+}

--- a/app/dashboard/route.tsx
+++ b/app/dashboard/route.tsx
@@ -4,7 +4,7 @@ import {
   ExclamationmarkTriangleFillIcon,
   QuestionmarkDiamondFillIcon,
 } from '@navikt/aksel-icons'
-import { BodyShort, Box, Heading, HGrid, Skeleton, VStack } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, Heading, HGrid, Skeleton, VStack } from '@navikt/ds-react'
 import React from 'react'
 import { Await } from 'react-router'
 import type { BrevTidsserieResponse, TidsserieResponse } from '~/analyse/types'
@@ -92,7 +92,14 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
         </VStack>
       }
     >
-      <Await resolve={loadingDashboardResponse}>
+      <Await
+        resolve={loadingDashboardResponse}
+        errorElement={
+          <Alert variant="warning">
+            Dashboard-data kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden på nytt.
+          </Alert>
+        }
+      >
         {(dashboardResponse) => {
           return (
             dashboardResponse && (

--- a/app/konsistensavstemming/konsistensavstemming.stories.tsx
+++ b/app/konsistensavstemming/konsistensavstemming.stories.tsx
@@ -24,3 +24,11 @@ export const Empty: Story = {
       behandlinger: mockBehandlingerPage([], { empty: true }),
     }),
 }
+
+export const FeilendeData: Story = {
+  tags: ['error-expected'],
+  render: () =>
+    renderWithLoader(Konsistensavstemming, {
+      behandlinger: Promise.reject(new Error('Tidsavbrudd')),
+    }),
+}

--- a/app/konsistensavstemming/konsistensavstemming.tsx
+++ b/app/konsistensavstemming/konsistensavstemming.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   BodyLong,
   Box,
   Button,
@@ -185,7 +186,14 @@ export default function Konsistensavstemming({ loaderData }: Route.ComponentProp
         Eksisterende avstemminger
       </Heading>
       <Suspense fallback={<Skeleton variant="rectangle" width="100%" height={407} />}>
-        <Await resolve={behandlinger}>
+        <Await
+          resolve={behandlinger}
+          errorElement={
+            <Alert variant="warning">
+              Avstemminger kunne ikke lastes. Dette kan skyldes tregt svar fra tjenesten. Forsøk å laste siden på nytt.
+            </Alert>
+          }
+        >
           {(it) => (
             <BehandlingerTable
               inkluderFortsett={false}


### PR DESCRIPTION
## Problem

Feil eller tidsavbrudd i strømmede (deferred) løfter førte til at hele siden krasjet med «Operasjon feilet». Dette var synlig på bl.a. `/behandling/:id/avhengigeBehandlinger`.

Disse sidene/komponentene manglet `errorElement` på `<Await>`:
- `behandling.$behandlingId.avhengigeBehandlinger`
- `behandling.$behandlingId.ikkeFullforteAktiviteter`
- `adhoc-brev`
- `konsistensavstemming`
- `avstemming`
- `dashboard`

## Løsning

Lagt til `errorElement` med `Alert variant="warning"` på alle `<Await>`-komponenter som manglet det. Feil vises nå inline der dataene ellers ville blitt vist, og resten av siden fungerer normalt.

Samme mønster som ble brukt i #783 og som allerede finnes i `LokiLogsTableLoader.tsx`.