### PR TITLE
fix: rett komponentnavn i ikkeFullforteAktiviteter-rute

### DIFF
--- a/app/behandling/behandling.$behandlingId.ikkeFullforteAktiviteter.tsx
+++ b/app/behandling/behandling.$behandlingId.ikkeFullforteAktiviteter.tsx
@@ -16,7 +16,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
   }
 }
 
-export default function AvhengigeBehandlinger({ loaderData }: Route.ComponentProps) {
+export default function IkkeFullforteAktiviteterRoute({ loaderData }: Route.ComponentProps) {
   const { ikkeFullforteAktiviteter } = loaderData
 
   return (


### PR DESCRIPTION
Følger opp review-kommentar fra #784.

Default-eksporten i `behandling.$behandlingId.ikkeFullforteAktiviteter.tsx` het `AvhengigeBehandlinger` — en copy/paste-feil fra `avhengigeBehandlinger`-ruten. Rettet til `IkkeFullforteAktiviteterRoute` slik at komponentnavnet er korrekt i React DevTools og stack traces.