### PR TITLE
fix: øk timeout til 60s for tunge aggregerings-endepunkter

### DIFF
--- a/app/services/api.server.ts
+++ b/app/services/api.server.ts
@@ -35,11 +35,11 @@ async function apiFetch<T>(
   path: string,
   requestCtx: RequestCtx | Request,
   parse: (res: Response) => Promise<T>,
-  opts?: { allow404AsUndefined?: boolean; body?: unknown },
+  opts?: { allow404AsUndefined?: boolean; body?: unknown; timeoutMs?: number },
 ): Promise<T | undefined> {
   const ctx = await resolveCtx(requestCtx)
   const url = `${env.penUrl}${path}`
-  const { signal, cancel } = withTimeout(15_000)
+  const { signal, cancel } = withTimeout(opts?.timeoutMs ?? 15_000)
   const start = performance.now()
   try {
     const headers: HeadersInit = { ...buildHeaders(ctx) }
@@ -81,8 +81,12 @@ async function apiFetch<T>(
   }
 }
 
-export async function apiGet<T>(path: string, requestCtx: RequestCtx | Request): Promise<T> {
-  const result = await apiFetch<T>('GET', path, requestCtx, async (res) => (await res.json()) as T)
+export async function apiGet<T>(
+  path: string,
+  requestCtx: RequestCtx | Request,
+  opts?: { timeoutMs?: number },
+): Promise<T> {
+  const result = await apiFetch<T>('GET', path, requestCtx, async (res) => (await res.json()) as T, opts)
   // apiFetch never returns undefined here since allow404AsUndefined is not used
   return result as T
 }
@@ -92,8 +96,15 @@ export async function apiGetRawResponse(path: string, requestCtx: RequestCtx | R
   return result as Response
 }
 
-export async function apiGetOrUndefined<T>(path: string, requestCtx: RequestCtx | Request): Promise<T | undefined> {
-  return apiFetch<T>('GET', path, requestCtx, async (res) => (await res.json()) as T, { allow404AsUndefined: true })
+export async function apiGetOrUndefined<T>(
+  path: string,
+  requestCtx: RequestCtx | Request,
+  opts?: { timeoutMs?: number },
+): Promise<T | undefined> {
+  return apiFetch<T>('GET', path, requestCtx, async (res) => (await res.json()) as T, {
+    ...opts,
+    allow404AsUndefined: true,
+  })
 }
 
 export async function apiGetRawStringOrUndefined(

--- a/app/services/behandling.server.ts
+++ b/app/services/behandling.server.ts
@@ -88,7 +88,9 @@ export async function getAvhengigeBehandlinger(
   if (sort) params.set('sort', sort)
   if (ansvarligTeam) params.set('ansvarligTeam', ansvarligTeam)
 
-  return await apiGet<BehandlingerPage>(`/api/behandling/${behandlingId}/avhengigeBehandlinger?${params}`, request)
+  return await apiGet<BehandlingerPage>(`/api/behandling/${behandlingId}/avhengigeBehandlinger?${params}`, request, {
+    timeoutMs: 60_000,
+  })
 }
 
 export async function search(
@@ -131,11 +133,18 @@ export async function getDetaljertFremdrift(
   return await apiGetOrUndefined<DetaljertFremdriftDTO>(
     `/api/behandling/${forrigeBehandlingId}/detaljertfremdrift`,
     request,
+    { timeoutMs: 60_000 },
   )
 }
 
 export async function getIkkeFullforteAktiviteter(request: Request, behandlingId: number) {
-  return await apiGet<IkkeFullforteAktiviteterDTO>(`/api/behandling/${behandlingId}/ikkeFullforteAktiviteter`, request)
+  return await apiGet<IkkeFullforteAktiviteterDTO>(
+    `/api/behandling/${behandlingId}/ikkeFullforteAktiviteter`,
+    request,
+    {
+      timeoutMs: 60_000,
+    },
+  )
 }
 
 export async function fortsettBehandling(


### PR DESCRIPTION
## Problem

Tre komponenter på `/behandling/:id/avhengigeBehandlinger` feilet pga. timeout for store kjøringer (f.eks. `108539333`):
- **Fremdriftsdata** (`detaljertfremdrift`)
- **Avhengige behandlinger** (`avhengigeBehandlinger`)
- **Uferdige aktiviteter** (`ikkeFullforteAktiviteter`)

Disse endepunktene aggregerer data på tvers av mange barn-behandlinger og kan ta betydelig lengre tid enn de 15 sekundene som var satt som global timeout.

## Løsning

Lagt til valgfri `timeoutMs`-parameter i `apiGet` og `apiGetOrUndefined` (standard forblir 15s). De tre tunge kall-stedene bruker nå 60s:

```ts
apiGet(..., request, { timeoutMs: 60_000 })
```

Siden disse kalles som deferred Promises (siden vises umiddelbart), påvirker ikke lengre timeout brukeropplevelsen — data strømmer inn når de er klare, og ved feil vises `Alert` inline.