### PR TITLE
Legg til dependabot-gruppe for vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
         patterns:
           - "@react-router*"
           - "react-router"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@storybook/addon-vitest"
       storybook:
         patterns:
           - 'storybook'


### PR DESCRIPTION
Grupperer vitest, @vitest/* og @storybook/addon-vitest i egen dependabot-gruppe.