### PR TITLE
Fjern @storybook/addon-vitest fra vitest-gruppen i dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,6 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
-          - "@storybook/addon-vitest"
       storybook:
         patterns:
           - 'storybook'


### PR DESCRIPTION
Pakken følger Storybook-versjonering (`^10.4.6`), ikke Vitest (`^4.1.8`), og hører derfor hjemme i `storybook`-gruppen sammen med de andre `@storybook/*`-pakkene.